### PR TITLE
Add some generative tests for Vmap and Umap

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <config>
     <add key="repositoryPath" value="./Packages" />

--- a/Prime/Prime/Prime/App.config
+++ b/Prime/Prime/Prime/App.config
@@ -4,11 +4,23 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.3.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.3.1.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="2.3.5.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.78.3.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.259.3.1" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="4.3.1.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.47.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.78.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="3.259.4.0" newVersion="4.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
 </configuration>

--- a/Prime/Prime/Prime/App.config
+++ b/Prime/Prime/Prime/App.config
@@ -4,19 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.5.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.0.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.3.0.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.3.1.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="2.3.5.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.78.3.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.259.3.1" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="4.3.1.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.47.4.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.78.4.0" newVersion="4.4.0.0" />
-        <bindingRedirect oldVersion="3.259.4.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Prime/Prime/Prime/MapTests.fs
+++ b/Prime/Prime/Prime/MapTests.fs
@@ -1,0 +1,79 @@
+﻿// Prime - A PRIMitivEs code library.
+// Copyright (C) Bryan Edds, 2012-2016.
+
+namespace Prime.Tests
+open System
+open System.IO
+open System.Collections.Generic
+open Xunit
+open FsCheck
+open FsCheck.Xunit
+open Prime
+
+module MapTests =
+    type [<RequireQualifiedAccess>] MapAction = 
+        | SetKey
+        | RemoveRandom
+
+    let inline eqDictAfterSteps
+        (actions: MapAction[]) 
+        (mapCtor: unit->'m) 
+        (setKey: 'k->'v->'m->'m when 'k: comparison and 'v: comparison) 
+        (removeKey: 'k->'m->'m when 'k: comparison and 'v: comparison) 
+        (genKey: Gen<'k>) 
+        (genVal: Gen<'v>) 
+        (eqDict: 'm->Dictionary<'k, 'v>->bool) =
+
+        let testMap = ref (mapCtor())
+        let dict = Dictionary<'k, 'v>()
+        
+        for action in actions do
+            match action with
+            | MapAction.SetKey ->
+                let k = genKey.Sample(0, 1).Head
+                let v = genVal.Sample(0, 1).Head
+                dict.[k] <- v
+                testMap := setKey k v !testMap
+            | MapAction.RemoveRandom ->
+                if dict.Keys.Count > 0 then
+                    let idx = Gen.choose(0, dict.Keys.Count - 1).Sample(0, 1).Head
+                    let k = dict.Keys |> Seq.item idx
+                    let _ = dict.Remove(k)
+                    testMap := removeKey k !testMap
+        eqDict !testMap dict
+
+    [<Property>]
+    let vMapEqualsDictionaryAfterSteps (actions: MapAction[]) =
+        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
+        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
+        let eqDict (m:Vmap<_,_>) (dict:Dictionary<_,_>) =
+            dict.Keys
+            |> Seq.cast<_>
+            |> Seq.forall(fun k ->
+                let dictVal = dict.[k]
+                let vmapVal = Vmap.find k m
+                dictVal = vmapVal)
+        eqDictAfterSteps actions (Vmap.makeEmpty) (Vmap.add) (Vmap.remove) genKey genVal eqDict
+
+    [<Property>]
+    let uMapEqualsDictionaryAfterSteps (actions: MapAction[]) =
+        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
+        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
+        let eqDict (m:Umap<_,_>) (dict:Dictionary<_,_>) =
+            dict.Keys
+            |> Seq.cast<_>
+            |> Seq.forall(fun k ->
+                let dictVal = dict.[k]
+                let vmapVal = Umap.find k m
+                dictVal = vmapVal)
+        let ctor() = Umap.makeEmpty(None)
+        eqDictAfterSteps actions ctor (Umap.add) (Umap.remove) genKey genVal eqDict
+
+       
+
+            
+
+    
+
+    
+

--- a/Prime/Prime/Prime/MapTests.fs
+++ b/Prime/Prime/Prime/MapTests.fs
@@ -11,74 +11,24 @@ open FsCheck.Xunit
 open Prime
 
 module MapTests =
-    type [<RequireQualifiedAccess>] MapAction = 
-        | SetKey
+    type [<RequireQualifiedAccess>] MapAction<'k, 'v> = 
+        | SetKey of 'k * 'v
         | RemoveRandom
-
-    /// Checks if a map is equal to a dictionary with the all the actions applied
-    let inline eqDictAfterSteps
-        (actions: MapAction[]) 
-        (mapCtor: unit->'m) 
-        (setKey: 'k->'v->'m->'m when 'k: comparison and 'v: comparison) 
-        (removeKey: 'k->'m->'m when 'k: comparison and 'v: comparison) 
-        (genKey: Gen<'k>) 
-        (genVal: Gen<'v>) 
-        (eqDict: 'm->Dictionary<'k, 'v>->bool) =
-
-        let testMap = ref (mapCtor())
-        let dict = Dictionary<'k, 'v>()
-        
-        for action in actions do
-            match action with
-            | MapAction.SetKey ->
-                let k = genKey.Sample(0, 1).Head
-                let v = genVal.Sample(0, 1).Head
-                dict.[k] <- v
-                testMap := setKey k v !testMap
-            | MapAction.RemoveRandom ->
-                if dict.Keys.Count > 0 then
-                    let idx = Gen.choose(0, dict.Keys.Count - 1).Sample(0, 1).Head
-                    let k = dict.Keys |> Seq.item idx
-                    let _ = dict.Remove(k)
-                    testMap := removeKey k !testMap
-        eqDict !testMap dict
-
-    [<Property>]
-    let vMapEqualsDictionaryAfterSteps (actions: MapAction[]) =
-        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let eqDict (m:Vmap<_,_>) (dict:Dictionary<_,_>) =
-            Seq.forall (fun (KeyValue(k,v)) -> Vmap.find k m = v) dict
-
-        eqDictAfterSteps actions (Vmap.makeEmpty) (Vmap.add) (Vmap.remove) genKey genVal eqDict
-
-    [<Property>]
-    let uMapEqualsDictionaryAfterSteps (actions: MapAction[]) =
-        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let eqDict (m:Umap<_,_>) (dict:Dictionary<_,_>) =
-            Seq.forall (fun (KeyValue(k,v)) -> Umap.find k m = v) dict
-        let ctor() = Umap.makeEmpty(None)
-
-        eqDictAfterSteps actions ctor (Umap.add) (Umap.remove) genKey genVal eqDict
 
     /// Keeps a reference to all persistent collections returned after
     /// performing an action, and after they are all applied, checks
     /// that they equal what we would get from FSharp.Core.Map
     let inline eqMapsAfterSteps
-        (actions: MapAction[])
-        (mapCtor: unit->'m)
+        (fsMap:Map<'k, 'v>)
+        (testMap:'m)
+        (actions: MapAction<'k, 'v>[])
         (setKey: 'k->'v->'m->'m when 'k: comparison and 'v: comparison)
         (removeKey: 'k->'m->'m when 'k: comparison and 'v: comparison)
-        (genKey: Gen<'k>)
-        (genVal: Gen<'v>)
-        (eqDict: 'm->Map<'k, 'v>->bool) =
+        (eqMap: 'm->Map<'k, 'v>->bool) =
 
         let applyAction fsMap testMap action =
             match action with
-            | MapAction.SetKey ->
-                let k = genKey.Sample(0, 1).Head
-                let v = genVal.Sample(0, 1).Head
+            | MapAction.SetKey(k, v) ->
                 (Map.add k v fsMap, setKey k v testMap)
             | MapAction.RemoveRandom when Map.isEmpty fsMap ->
                 (fsMap, testMap)
@@ -96,29 +46,38 @@ module MapTests =
                         let (newF, newT) = applyAction fsMap testMap action
                         (newF::fsMap::fsMaps, newT::testMap::testMaps)
                     | _ -> failwith "Logic error")
-                ([Map.empty], [mapCtor()])
+                ([fsMap], [testMap])
                 actions
 
         List.forall2
-            eqDict
+            eqMap
             testMaps
             fsMaps
 
     [<Property>]
-    let vMapsEqualFsMapsAfterSteps (actions: MapAction[]) =
-        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let eqDict (m:Vmap<_,_>) (dict:Map<_,_>) =
-            Seq.forall (fun (KeyValue(k,v)) -> Vmap.find k m = v) dict
+    let vMapsEqualFsMapsAfterSteps (startFsMap:Map<int, string>) (actions: MapAction<int, string>[]) =
+        let testMap = Vmap.ofSeq ^ Map.toSeq startFsMap
+        let eqMap (m:Vmap<_,_>) (dict:Map<_,_>) =
+            Map.ofSeq ^ Vmap.toSeq m = dict
 
-        eqMapsAfterSteps actions (Vmap.makeEmpty) (Vmap.add) (Vmap.remove) genKey genVal eqDict
+        eqMapsAfterSteps 
+            startFsMap
+            testMap
+            actions
+            (Vmap.add) 
+            (Vmap.remove)
+            eqMap
 
     [<Property>]
-    let uMapsEqualFsMapsAfterSteps (actions: MapAction[]) =
-        let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
-        let eqDict (m:Umap<_,_>) (dict:Map<_,_>) =
-            Seq.forall (fun (KeyValue(k,v)) -> Umap.find k m = v) dict
-        let ctor() = Umap.makeEmpty(None)
+    let uMapsEqualFsMapsAfterSteps (startFsMap:Map<int, string>) (actions: MapAction<int, string>[]) =
+        let testMap = Umap.ofSeq ^ Map.toSeq startFsMap
+        let eqMap (m:Umap<_,_>) (dict:Map<_,_>) =
+            Map.ofSeq ^ Umap.toSeq m = dict
 
-        eqMapsAfterSteps actions ctor (Umap.add) (Umap.remove) genKey genVal eqDict
+        eqMapsAfterSteps 
+            startFsMap
+            testMap
+            actions
+            (Umap.add) 
+            (Umap.remove)
+            eqMap

--- a/Prime/Prime/Prime/MapTests.fs
+++ b/Prime/Prime/Prime/MapTests.fs
@@ -47,12 +47,8 @@ module MapTests =
         let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
         let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
         let eqDict (m:Vmap<_,_>) (dict:Dictionary<_,_>) =
-            dict.Keys
-            |> Seq.cast<_>
-            |> Seq.forall(fun k ->
-                let dictVal = dict.[k]
-                let vmapVal = Vmap.find k m
-                dictVal = vmapVal)
+            Seq.forall (fun (KeyValue(k,v)) -> Vmap.find k m = v) dict
+
         eqDictAfterSteps actions (Vmap.makeEmpty) (Vmap.add) (Vmap.remove) genKey genVal eqDict
 
     [<Property>]
@@ -60,20 +56,7 @@ module MapTests =
         let genKey = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
         let genVal = Gen.choose(Int32.MinValue + 1, Int32.MaxValue)
         let eqDict (m:Umap<_,_>) (dict:Dictionary<_,_>) =
-            dict.Keys
-            |> Seq.cast<_>
-            |> Seq.forall(fun k ->
-                let dictVal = dict.[k]
-                let vmapVal = Umap.find k m
-                dictVal = vmapVal)
+            Seq.forall (fun (KeyValue(k,v)) -> Umap.find k m = v) dict
         let ctor() = Umap.makeEmpty(None)
+
         eqDictAfterSteps actions ctor (Umap.add) (Umap.remove) genKey genVal eqDict
-
-       
-
-            
-
-    
-
-    
-

--- a/Prime/Prime/Prime/Packages.config
+++ b/Prime/Prime/Prime/Packages.config
@@ -1,4 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net40" />
+  <package id="FsCheck" version="2.6.0" targetFramework="net45" />
+  <package id="FsCheck.Xunit" version="2.6.0" targetFramework="net45" />
+  <package id="FSharp.Core" version="3.1.2.5" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net4" />
 </packages>

--- a/Prime/Prime/Prime/Prime.fsproj
+++ b/Prime/Prime/Prime/Prime.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Prime</RootNamespace>
     <AssemblyName>Prime</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <Name>Prime</Name>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <TargetFrameworkProfile />
@@ -114,6 +114,7 @@
     <Compile Include="SymbolTests.fs" />
     <Compile Include="XtensionTests.fs" />
     <Compile Include="EventTests.fs" />
+    <Compile Include="MapTests.fs" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Program.fs" />
     <None Include="Interactive.fsx" />
@@ -127,7 +128,12 @@
     <Reference Include="FParsecCS">
       <HintPath>..\..\FParsec\FParsecCS.dll</HintPath>
     </Reference>
-    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <Reference Include="FsCheck">
+      <HintPath>..\..\..\.\Packages\FsCheck.2.6.0\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsCheck.Xunit">
+      <HintPath>..\..\..\.\Packages\FsCheck.Xunit.2.6.0\lib\net45\FsCheck.Xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -136,6 +142,18 @@
     <Reference Include="System.Numerics" />
     <Reference Include="xunit">
       <HintPath>..\..\xUnit\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\..\.\Packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\..\.\Packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop">
+      <HintPath>..\..\..\.\Packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Added some generative tests for Vmap and Umap. 

It just randomly generates a sequence of actions (Add | Remove) to perform on an empty map, and applies them while maintaining a dictionary, then checks to see if they are equal afterwards. There is also one that does the same, except maintains a list of FSharp.Core.Maps, and checks equality going back.

Inspired by this approach, which found some bugs for people in the Clojure community:

https://github.com/ztellman/collection-check

If you add `(Verbose=True)` on the `Property`, you can see the tests it ran:

![image](https://cloud.githubusercontent.com/assets/607986/17723314/6a4f71ec-63f6-11e6-8185-2b4e34c3e257.png)

The tests pass for both Maps. :+1: .