### PR TITLE
Use unique names for each template.

### DIFF
--- a/Nu/Nu.Gaia/Gaia.fs
+++ b/Nu/Nu.Gaia/Gaia.fs
@@ -3363,12 +3363,12 @@ DockSpace             ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,0 Size=1920,1080 Spl
 
                 // choose a template, ensuring it exists
                 let slnDir = PathF.GetFullPath (programDir + "/../../../../..")
-                let (templateFileName, templateDir, editMode) =
+                let (templateFileName, templateDir, editMode, templateShortName) =
                     match NewProjectType with
-                    | "MMCC Empty" -> ("Nu.Template.Mmcc.Empty.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.Mmcc.Empty"), "Initial")
-                    | "MMCC Game" -> ("Nu.Template.Mmcc.Game.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.Mmcc.Game"), "Title")
-                    | "ImNui Empty" -> ("Nu.Template.ImNui.Empty.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.ImNui.Empty"), "Initial")
-                    | "ImNui Game" -> ("Nu.Template.ImNui.Game.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.ImNui.Game"), "Title")
+                    | "MMCC Empty" -> ("Nu.Template.Mmcc.Empty.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.Mmcc.Empty"), "Initial", "nu-game-mmcc-empty")
+                    | "MMCC Game" -> ("Nu.Template.Mmcc.Game.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.Mmcc.Game"), "Title", "nu-game-mmcc-game")
+                    | "ImNui Empty" -> ("Nu.Template.ImNui.Empty.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.ImNui.Empty"), "Initial", "nu-game-imnui-empty")
+                    | "ImNui Game" -> ("Nu.Template.ImNui.Game.fsproj", PathF.GetFullPath (programDir + "/../../../../Nu.Template.ImNui.Game"), "Title", "nu-game-imnui-game")
                     | _ -> failwithumf ()
                 if Directory.Exists templateDir then
 
@@ -3383,7 +3383,7 @@ DockSpace             ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,0 Size=1920,1080 Spl
                         Directory.SetCurrentDirectory projectsDir
                         Directory.CreateDirectory NewProjectName |> ignore<DirectoryInfo>
                         Directory.SetCurrentDirectory newProjectDir
-                        Process.Start("dotnet", "new nu-game --force").WaitForExit()
+                        Process.Start("dotnet", "new " + templateShortName + " --force").WaitForExit()
 
                         // rename project file
                         File.Copy (templateFileName, newFileName, true)

--- a/Nu/Nu.Template.ImNui.Empty/.template.config/template.json
+++ b/Nu/Nu.Template.ImNui.Empty/.template.config/template.json
@@ -2,9 +2,9 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Bryan Edds",
   "classifications": [ "Nu", "Game" ],
-  "identity": "Nu Game",
-  "name": "Nu Game",
-  "shortName": "nu-game",
+  "identity": "Nu Game - ImNui Empty",
+  "name": "Nu Game - ImNui Empty",
+  "shortName": "nu-game-imnui-empty",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Nu/Nu.Template.ImNui.Game/.template.config/template.json
+++ b/Nu/Nu.Template.ImNui.Game/.template.config/template.json
@@ -2,9 +2,9 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Bryan Edds",
   "classifications": [ "Nu", "Game" ],
-  "identity": "Nu Game",
-  "name": "Nu Game",
-  "shortName": "nu-game",
+  "identity": "Nu Game - ImNui Game",
+  "name": "Nu Game - ImNui Game",
+  "shortName": "nu-game-imnui-game",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Nu/Nu.Template.Mmcc.Empty/.template.config/template.json
+++ b/Nu/Nu.Template.Mmcc.Empty/.template.config/template.json
@@ -2,9 +2,9 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Bryan Edds",
   "classifications": [ "Nu", "Game" ],
-  "identity": "Nu Game",
-  "name": "Nu Game",
-  "shortName": "nu-game",
+  "identity": "Nu Game - MMCC Empty",
+  "name": "Nu Game - MMCC Empty",
+  "shortName": "nu-game-mmcc-empty",
   "tags": {
     "language": "F#",
     "type": "project"

--- a/Nu/Nu.Template.Mmcc.Game/.template.config/template.json
+++ b/Nu/Nu.Template.Mmcc.Game/.template.config/template.json
@@ -2,9 +2,9 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Bryan Edds",
   "classifications": [ "Nu", "Game" ],
-  "identity": "Nu Game",
-  "name": "Nu Game",
-  "shortName": "nu-game",
+  "identity": "Nu Game - MMCC Game",
+  "name": "Nu Game - MMCC Game",
+  "shortName": "nu-game-mmcc-game",
   "tags": {
     "language": "F#",
     "type": "project"


### PR DESCRIPTION
Modified the `identity`, `name` and `shortName` to differentiate each template. This enables all the templates to be installed simultaneously.

Tested creating each project type through Gaia, works fine. 

You can also run `dotnet new install .` in the `/Nu` directory to install all the templates at once.

Fixes #880.
