### PR TITLE
Billboard-Feature

### DIFF
--- a/Nu/Nu/Render/Renderer3d.fs
+++ b/Nu/Nu/Render/Renderer3d.fs
@@ -1706,6 +1706,7 @@ type [<ReferenceEquality>] GlRenderer3d =
             | ShadowPass (_, _, _, _, _) -> Matrix4x4.CreateFromQuaternion lookRotation
             | _ ->
                 if orientUp && planarBillboard then
+                    // TODO: Implement orientUp and planar behavior
                     m4Identity
                 elif orientUp && not planarBillboard then
                     let eyeFlat = eyeCenter.WithY 0.0f

--- a/Nu/Nu/Render/Renderer3d.fs
+++ b/Nu/Nu/Render/Renderer3d.fs
@@ -391,6 +391,7 @@ type RenderBillboard =
       CastShadow : bool
       Presence : Presence
       InsetOpt : Box2 option
+      PlanarBillboard : bool
       MaterialProperties : MaterialProperties
       Material : Material
       ShadowOffset : single

--- a/Nu/Nu/Render/Renderer3d.fs
+++ b/Nu/Nu/Render/Renderer3d.fs
@@ -400,7 +400,7 @@ type RenderBillboard =
       RenderPass : RenderPass }
 
 type RenderBillboards =
-    { Billboards : (Matrix4x4 * bool * Presence * Box2 option) SList
+    { Billboards : (Matrix4x4 * bool * Presence * Box2 option * bool) SList
       MaterialProperties : MaterialProperties
       Material : Material
       ShadowOffset : single
@@ -1670,6 +1670,7 @@ type [<ReferenceEquality>] GlRenderer3d =
          castShadow : bool,
          presence : Presence,
          insetOpt : Box2 option,
+         planarBillboard : bool,
          albedoMetadata : OpenGL.Texture.TextureMetadata,
          properties,
          orientUp,
@@ -1703,7 +1704,7 @@ type [<ReferenceEquality>] GlRenderer3d =
             match renderPass with
             | ShadowPass (_, _, _, _, _) -> Matrix4x4.CreateFromQuaternion lookRotation
             | _ ->
-                if orientUp then
+                if orientUp && not planarBillboard then
                     let eyeFlat = eyeCenter.WithY 0.0f
                     let positionFlat = model.Translation.WithY 0.0f
                     let eyeToPositionFlat = positionFlat - eyeFlat
@@ -3123,12 +3124,12 @@ type [<ReferenceEquality>] GlRenderer3d =
             | RenderBillboard rb ->
                 let struct (billboardProperties, billboardMaterial) = GlRenderer3d.makeBillboardMaterial (&rb.MaterialProperties, &rb.Material, renderer)
                 let billboardSurface = OpenGL.PhysicallyBased.CreatePhysicallyBasedSurface (Array.empty, m4Identity, box3 (v3 -0.5f 0.5f -0.5f) v3One, billboardProperties, billboardMaterial, -1, Assimp.Node.Empty, renderer.BillboardGeometry)
-                GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, rb.ModelMatrix, rb.CastShadow, rb.Presence, rb.InsetOpt, billboardMaterial.AlbedoTexture.TextureMetadata, rb.MaterialProperties, true, rb.ShadowOffset, billboardSurface, rb.DepthTest, rb.RenderType, rb.RenderPass, renderer)
+                GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, rb.ModelMatrix, rb.CastShadow, rb.Presence, rb.InsetOpt, rb.PlanarBillboard, billboardMaterial.AlbedoTexture.TextureMetadata, rb.MaterialProperties, true, rb.ShadowOffset, billboardSurface, rb.DepthTest, rb.RenderType, rb.RenderPass, renderer)
             | RenderBillboards rbs ->
                 let struct (billboardProperties, billboardMaterial) = GlRenderer3d.makeBillboardMaterial (&rbs.MaterialProperties, &rbs.Material, renderer)
                 let billboardSurface = OpenGL.PhysicallyBased.CreatePhysicallyBasedSurface (Array.empty, m4Identity, box3 (v3 -0.5f -0.5f -0.5f) v3One, billboardProperties, billboardMaterial, -1, Assimp.Node.Empty, renderer.BillboardGeometry)
-                for (model, castShadow, presence, insetOpt) in rbs.Billboards do
-                    GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, model, castShadow, presence, insetOpt, billboardMaterial.AlbedoTexture.TextureMetadata, rbs.MaterialProperties, true, rbs.ShadowOffset, billboardSurface, rbs.DepthTest, rbs.RenderType, rbs.RenderPass, renderer)
+                for (model, castShadow, presence, insetOpt, planarBillboard) in rbs.Billboards do
+                    GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, model, castShadow, presence, insetOpt, planarBillboard, billboardMaterial.AlbedoTexture.TextureMetadata, rbs.MaterialProperties, true, rbs.ShadowOffset, billboardSurface, rbs.DepthTest, rbs.RenderType, rbs.RenderPass, renderer)
             | RenderBillboardParticles rbps ->
                 let struct (billboardProperties, billboardMaterial) = GlRenderer3d.makeBillboardMaterial (&rbps.MaterialProperties, &rbps.Material, renderer)
                 for particle in rbps.Particles do
@@ -3139,7 +3140,7 @@ type [<ReferenceEquality>] GlRenderer3d =
                              particle.Transform.Size * particle.Transform.Scale)
                     let billboardProperties = { billboardProperties with Albedo = billboardProperties.Albedo * particle.Color; Emission = particle.Emission.R }
                     let billboardSurface = OpenGL.PhysicallyBased.CreatePhysicallyBasedSurface (Array.empty, m4Identity, box3Zero, billboardProperties, billboardMaterial, -1, Assimp.Node.Empty, renderer.BillboardGeometry)
-                    GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, billboardMatrix, rbps.CastShadow, rbps.Presence, Option.ofValueOption particle.InsetOpt, billboardMaterial.AlbedoTexture.TextureMetadata, rbps.MaterialProperties, false, rbps.ShadowOffset, billboardSurface, rbps.DepthTest, rbps.RenderType, rbps.RenderPass, renderer)
+                    GlRenderer3d.categorizeBillboardSurface (eyeCenter, eyeRotation, billboardMatrix, rbps.CastShadow, rbps.Presence, Option.ofValueOption particle.InsetOpt, false, billboardMaterial.AlbedoTexture.TextureMetadata, rbps.MaterialProperties, false, rbps.ShadowOffset, billboardSurface, rbps.DepthTest, rbps.RenderType, rbps.RenderPass, renderer)
             | RenderStaticModelSurface rsms ->
                 let insetOpt = Option.toValueOption rsms.InsetOpt
                 GlRenderer3d.categorizeStaticModelSurfaceByIndex (&rsms.ModelMatrix, rsms.CastShadow, rsms.Presence, &insetOpt, &rsms.MaterialProperties, &rsms.Material, rsms.StaticModel, rsms.SurfaceIndex, rsms.DepthTest, rsms.RenderType, rsms.RenderPass, renderer)

--- a/Nu/Nu/Render/Renderer3d.fs
+++ b/Nu/Nu/Render/Renderer3d.fs
@@ -1707,7 +1707,13 @@ type [<ReferenceEquality>] GlRenderer3d =
             | _ ->
                 if orientUp && planarBillboard then
                     // TODO: Implement orientUp and planar behavior
-                    m4Identity
+                    let forwardFlat = eyeRotation.Forward.WithY 0.0f
+                    if forwardFlat.MagnitudeSquared > 0.0f then
+                        let forward = forwardFlat.Normalized
+                        let yaw = MathF.Atan2(forward.X, forward.Z) - MathF.PI
+                        Matrix4x4.CreateRotationY yaw
+                    else
+                        m4Identity
                 elif orientUp && not planarBillboard then
                     let eyeFlat = eyeCenter.WithY 0.0f
                     let positionFlat = model.Translation.WithY 0.0f

--- a/Nu/Nu/World/WorldDataToken.fs
+++ b/Nu/Nu/World/WorldDataToken.fs
@@ -58,6 +58,7 @@ module WorldDataToken =
                       ShadowOffset = billboard.ShadowOffset
                       DepthTest =  LessThanOrEqualTest
                       PlanarBillboard = false
+                      OrientUp = false
                       RenderType = billboard.RenderType
                       RenderPass = renderPass }
                 World.enqueueRenderMessage3d (RenderBillboard renderBillboard) world

--- a/Nu/Nu/World/WorldDataToken.fs
+++ b/Nu/Nu/World/WorldDataToken.fs
@@ -57,6 +57,7 @@ module WorldDataToken =
                       Material = billboard.Material
                       ShadowOffset = billboard.ShadowOffset
                       DepthTest =  LessThanOrEqualTest
+                      PlanarBillboard = false
                       RenderType = billboard.RenderType
                       RenderPass = renderPass }
                 World.enqueueRenderMessage3d (RenderBillboard renderBillboard) world

--- a/Nu/Nu/World/WorldFacets.fs
+++ b/Nu/Nu/World/WorldFacets.fs
@@ -2548,6 +2548,9 @@ module StaticBillboardFacetExtensions =
         member this.GetShadowOffset world : single = this.Get (nameof this.ShadowOffset) world
         member this.SetShadowOffset (value : single) world = this.Set (nameof this.ShadowOffset) value world
         member this.ShadowOffset = lens (nameof this.ShadowOffset) this this.GetShadowOffset this.SetShadowOffset
+        member this.GetPlanarBillboard world : bool = this.Get(nameof this.PlanarBillboard) world
+        member this.SetPlanarBillboard (value : bool) world = this.Set(nameof this.PlanarBillboard) value world
+        member this.PlanarBillboard = lens (nameof this.PlanarBillboard) this this.GetPlanarBillboard this.SetPlanarBillboard
 
 /// Augments an entity with a static billboard.
 type StaticBillboardFacet () =
@@ -2559,7 +2562,8 @@ type StaticBillboardFacet () =
          define Entity.Material Material.defaultMaterial
          define Entity.DepthTest LessThanOrEqualTest
          define Entity.RenderStyle Deferred
-         define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault]
+         define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault
+         define Entity.PlanarBillboard false]
 
     override this.Render (renderPass, entity, world) =
         let mutable transform = entity.GetTransform world
@@ -2572,13 +2576,15 @@ type StaticBillboardFacet () =
             let material = entity.GetMaterial world
             let shadowOffset = entity.GetShadowOffset world
             let depthTest = entity.GetDepthTest world
+            let planarBillboard = entity.GetPlanarBillboard world
             let renderType =
                 match entity.GetRenderStyle world with
                 | Deferred -> DeferredRenderType
                 | Forward (subsort, sort) -> ForwardRenderType (subsort, sort)
             World.enqueueRenderMessage3d
+            // update parameters for enque.
                 (RenderBillboard
-                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt
+                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard
                       MaterialProperties = properties; Material = material; ShadowOffset = shadowOffset; DepthTest = depthTest; RenderType = renderType; RenderPass = renderPass })
                 world
 
@@ -2619,7 +2625,8 @@ type AnimatedBillboardFacet () =
          define Entity.Material Material.defaultMaterial
          define Entity.DepthTest LessThanOrEqualTest
          define Entity.RenderStyle Deferred
-         define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault]
+         define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault
+         define Entity.PlanarBillboard false]
 
     override this.Update (entity, world) =
         if not (entity.GetEnabled world)
@@ -2637,13 +2644,14 @@ type AnimatedBillboardFacet () =
             let material = entity.GetMaterial world
             let shadowOffset = entity.GetShadowOffset world
             let depthTest = entity.GetDepthTest world
+            let planarBillboard = entity.GetPlanarBillboard world
             let renderType =
                 match entity.GetRenderStyle world with
                 | Deferred -> DeferredRenderType
                 | Forward (subsort, sort) -> ForwardRenderType (subsort, sort)
             World.enqueueRenderMessage3d
                 (RenderBillboard
-                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt
+                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard;
                       MaterialProperties = properties; Material = material; ShadowOffset = shadowOffset; DepthTest = depthTest; RenderType = renderType; RenderPass = renderPass })
                 world
 

--- a/Nu/Nu/World/WorldFacets.fs
+++ b/Nu/Nu/World/WorldFacets.fs
@@ -2551,6 +2551,9 @@ module StaticBillboardFacetExtensions =
         member this.GetPlanarBillboard world : bool = this.Get(nameof this.PlanarBillboard) world
         member this.SetPlanarBillboard (value : bool) world = this.Set(nameof this.PlanarBillboard) value world
         member this.PlanarBillboard = lens (nameof this.PlanarBillboard) this this.GetPlanarBillboard this.SetPlanarBillboard
+        member this.GetOrientUp world : bool = this.Get(nameof this.OrientUp) world
+        member this.SetOrientUp (value : bool) world = this.Set(nameof this.OrientUp) value world
+        member this.OrientUp = lens (nameof this.OrientUp) this this.GetOrientUp this.SetOrientUp
 
 /// Augments an entity with a static billboard.
 type StaticBillboardFacet () =
@@ -2563,7 +2566,8 @@ type StaticBillboardFacet () =
          define Entity.DepthTest LessThanOrEqualTest
          define Entity.RenderStyle Deferred
          define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault
-         define Entity.PlanarBillboard false]
+         define Entity.PlanarBillboard false
+         define Entity.OrientUp true]
 
     override this.Render (renderPass, entity, world) =
         let mutable transform = entity.GetTransform world
@@ -2577,13 +2581,14 @@ type StaticBillboardFacet () =
             let shadowOffset = entity.GetShadowOffset world
             let depthTest = entity.GetDepthTest world
             let planarBillboard = entity.GetPlanarBillboard world
+            let orientUp = entity.GetOrientUp world
             let renderType =
                 match entity.GetRenderStyle world with
                 | Deferred -> DeferredRenderType
                 | Forward (subsort, sort) -> ForwardRenderType (subsort, sort)
             World.enqueueRenderMessage3d
                 (RenderBillboard
-                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard
+                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard; OrientUp = orientUp;
                       MaterialProperties = properties; Material = material; ShadowOffset = shadowOffset; DepthTest = depthTest; RenderType = renderType; RenderPass = renderPass })
                 world
 
@@ -2625,7 +2630,8 @@ type AnimatedBillboardFacet () =
          define Entity.DepthTest LessThanOrEqualTest
          define Entity.RenderStyle Deferred
          define Entity.ShadowOffset Constants.Engine.BillboardShadowOffsetDefault
-         define Entity.PlanarBillboard false]
+         define Entity.PlanarBillboard false
+         define Entity.OrientUp true]
 
     override this.Update (entity, world) =
         if not (entity.GetEnabled world)
@@ -2644,13 +2650,14 @@ type AnimatedBillboardFacet () =
             let shadowOffset = entity.GetShadowOffset world
             let depthTest = entity.GetDepthTest world
             let planarBillboard = entity.GetPlanarBillboard world
+            let orientUp = entity.GetOrientUp world
             let renderType =
                 match entity.GetRenderStyle world with
                 | Deferred -> DeferredRenderType
                 | Forward (subsort, sort) -> ForwardRenderType (subsort, sort)
             World.enqueueRenderMessage3d
                 (RenderBillboard
-                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard;
+                    { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard; OrientUp = orientUp;
                       MaterialProperties = properties; Material = material; ShadowOffset = shadowOffset; DepthTest = depthTest; RenderType = renderType; RenderPass = renderPass })
                 world
 

--- a/Nu/Nu/World/WorldFacets.fs
+++ b/Nu/Nu/World/WorldFacets.fs
@@ -2582,7 +2582,6 @@ type StaticBillboardFacet () =
                 | Deferred -> DeferredRenderType
                 | Forward (subsort, sort) -> ForwardRenderType (subsort, sort)
             World.enqueueRenderMessage3d
-            // update parameters for enque.
                 (RenderBillboard
                     { CastShadow = castShadow; Presence = presence; ModelMatrix = affineMatrix; InsetOpt = insetOpt; PlanarBillboard = planarBillboard
                       MaterialProperties = properties; Material = material; ShadowOffset = shadowOffset; DepthTest = depthTest; RenderType = renderType; RenderPass = renderPass })


### PR DESCRIPTION
**Billboard-Feature**

A short PR that adds two flags to the Gaia UI, enabling users to specify whether or not billboards, which are always facing the camera, should be planar or orientedUp. 

Concerns / Thoughts:
I'm wondering if `orientUp`, which has a hardcoded value during message categorization is actually what we want to expose here. Perhaps there is a more generic way to describe billboard behavior? 

For example, in some texts planar behavior is described as screen-aligned. There is also world-oriented and axial. 

Fixes #964 