### PR TITLE
Disable DPI zoom on Windows

### DIFF
--- a/Nu/Nu.Gaia/Program.fs
+++ b/Nu/Nu.Gaia/Program.fs
@@ -1,15 +1,17 @@
-﻿// Gaia - The Nu Game Engine editor.
+// Gaia - The Nu Game Engine editor.
 // Copyright (C) Bryan Edds.
 
 namespace Nu.Gaia
 open System
 open System.IO
-open Prime
+open System.Runtime.InteropServices
 open Nu
 open Nu.Gaia
 module Program =
-
+    [<DllImport("user32.dll")>]
+    extern bool SetProcessDPIAware()
     let [<EntryPoint; STAThread>] main _ =
         Directory.SetCurrentDirectory AppContext.BaseDirectory
+        if OperatingSystem.IsWindows() then SetProcessDPIAware() |> ignore // Disable DPI zoom on Windows, otherwise the scaled UI will be cut off
         let (gaiaState, targetDir, plugin) = Nu.initPlus (fun () -> Gaia.selectNuPlugin (GaiaPlugin ()))
         Gaia.run gaiaState targetDir plugin


### PR DESCRIPTION
Before (150% DPI zoom):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ca763a77-abac-4cd3-a469-9b491b2a0bca" />

After (150% DPI zoom):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6e610bf7-1279-4104-983a-cc87752d82d4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0499df5b-95ce-498b-908a-85ecfe397495" />

Credits to https://stackoverflow.com/questions/51768519/disabling-windows-10-scaling-for-specific-application