### PR TITLE
Use nested record update syntax

### DIFF
--- a/Nu/Nu.Template.ImSim.Empty/Program.fs
+++ b/Nu/Nu.Template.ImSim.Empty/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "My Game" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "My Game" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (MyGamePlugin ())

--- a/Nu/Nu.Template.ImSim.Game/Program.fs
+++ b/Nu/Nu.Template.ImSim.Game/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "My Game" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "My Game" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (MyGamePlugin ())

--- a/Nu/Nu.Template.Mmcc.Empty/Program.fs
+++ b/Nu/Nu.Template.Mmcc.Empty/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "My Game" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "My Game" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (MyGamePlugin ())

--- a/Nu/Nu.Template.Mmcc.Game/Program.fs
+++ b/Nu/Nu.Template.Mmcc.Game/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "My Game" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "My Game" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (MyGamePlugin ())

--- a/Projects/Blaze Vector ImSim/Program.fs
+++ b/Projects/Blaze Vector ImSim/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for the BlazeVector application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Blaze Vector ImSim" }
-        
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Blaze Vector ImSim" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (BlazeVectorPlugin ())

--- a/Projects/Blaze Vector Mmcc/Program.fs
+++ b/Projects/Blaze Vector Mmcc/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for the BlazeVector application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Blaze Vector Mmcc" }
-        
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Blaze Vector ImSim" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (BlazeVectorPlugin ())

--- a/Projects/Breakout ImSim/Program.fs
+++ b/Projects/Breakout ImSim/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Breakout ImSim" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Breakout ImSim" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (BreakoutPlugin ())

--- a/Projects/Breakout Mmcc/Program.fs
+++ b/Projects/Breakout Mmcc/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Breakout Mmcc" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Breakout Mmcc" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (BreakoutPlugin ())

--- a/Projects/Jump Box/Program.fs
+++ b/Projects/Jump Box/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "My Game" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Jump Box" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (JumpBoxPlugin ())

--- a/Projects/Metrics/Program.fs
+++ b/Projects/Metrics/Program.fs
@@ -4,6 +4,7 @@ open System.IO
 open System.Numerics
 open Prime
 open Nu
+open type WorldConfig
 
 type MetricsEntityDispatcher () =
     inherit Entity3dDispatcher<StaticModel AssetTag, Message, Command> (false, false, false, Assets.Default.StaticModel)
@@ -134,7 +135,5 @@ module Program =
     let [<EntryPoint; STAThread>] main _ =
         Directory.SetCurrentDirectory AppContext.BaseDirectory
         Nu.init ()
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Metrics" }
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Metrics" }
         World.run worldConfig (MetricsPlugin ())

--- a/Projects/Nelmish/Program.fs
+++ b/Projects/Nelmish/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Nelmish" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Nelmish" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (NelmishPlugin ())

--- a/Projects/Terra Firma/Program.fs
+++ b/Projects/Terra Firma/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Terra Firma" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Terra Firma" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (TerraFirmaPlugin ())

--- a/Projects/Twenty 48/Program.fs
+++ b/Projects/Twenty 48/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open Nu
+open type WorldConfig
 module Program =
 
     // this the entry point for your Nu application
@@ -13,14 +14,8 @@ module Program =
         // this initializes Nu before other Nu code is run
         Nu.init ()
 
-        // this specifies the window configuration used to display the game
-        let sdlWindowConfig = { SdlWindowConfig.defaultConfig with WindowTitle = "Twenty 48" }
-
-        // this specifies the configuration of the game engine's use of SDL
-        let sdlConfig = { SdlConfig.defaultConfig with WindowConfig = sdlWindowConfig }
-
-        // this specifies the world config using the above SDL config
-        let worldConfig = { WorldConfig.defaultConfig with SdlConfig = sdlConfig }
+        // this specifies the configuration used to display the game
+        let worldConfig = { defaultConfig with WorldConfig.SdlConfig.WindowConfig.WindowTitle = "Twenty 48" }
 
         // this runs the engine with the given config and plugin, starting the game
         World.run worldConfig (Twenty48Plugin ())


### PR DESCRIPTION
Note:
- Prefixing with the type is required for backward compatibility with type-based lookup of record fields: https://github.com/dotnet/fsharp/issues/16180
- A compiler bug prevents at-least-triply nested record updates with non-simple-identifier record targets from working: https://github.com/dotnet/fsharp/issues/18062