### PR TITLE
Fix: Closing release-application from "x"-button.

### DIFF
--- a/Nu/Nu/World/WorldModule2.fs
+++ b/Nu/Nu/World/WorldModule2.fs
@@ -1125,8 +1125,12 @@ module WorldModule2 =
             match evt.Type with
             | SDL_EventType.SDL_EVENT_QUIT ->
                 if world.Accompanied then
+                    // accompanied (in an editor): forward as a request so the editor can handle it
                     let eventTrace = EventTrace.debug "World" "processInput2" "ExitRequest" EventTrace.empty
                     World.publishPlus () Nu.Game.Handle.ExitRequestEvent eventTrace Nu.Game.Handle true true world
+                else
+                    // unaccompanied (standalone game): closing the window exits the program
+                    World.exit world
             | SDL_EventType.SDL_EVENT_WINDOW_RESIZED ->
 
                 // ensure window size is a factor of display virtual resolution, going to full screen otherwise


### PR DESCRIPTION
I have an issue: if I press the close "X" in the windowed application (not the editor), nothing happens. The X should close the window.
