### PR TITLE
True splash screen for desktop

### DIFF
--- a/Nu/Nu.Gaia/Gaia.fs
+++ b/Nu/Nu.Gaia/Gaia.fs
@@ -1729,7 +1729,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
             | Some (DragDropAsset (_, assetTag)) when
                 ImGui.IsMouseReleased ImGuiMouseButton.Left &&
                 not io.WantCaptureMouse &&
-                (*not (NativePtr.isNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr)*)true ->
+                (*NativePtr.notNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr*)true ->
                 match Metadata.tryGetMetadata assetTag with
                 | ValueSome metadata ->
                     match metadata with
@@ -1922,7 +1922,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
         if openPopupContextItemWhenUnselected then
             ImGui.OpenPopup popupContextItemTitle
         if ImGui.BeginDragDropTarget () then
-            if not (NativePtr.isNullPtr (ImGui.AcceptDragDropPayload "Entity").NativePtr) then
+            if NativePtr.notNullPtr (ImGui.AcceptDragDropPayload "Entity").NativePtr then
                 match DragDropPayloadOpt with
                 | Some (DragDropEntity sourceEntity) ->
                     if sourceEntity.GetProtection world = Unprotected then
@@ -2866,7 +2866,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
                         if group.Name = selectedGroupName then ImGui.SetItemDefaultFocus ()
                     ImGui.EndCombo ()
                 if ImGui.BeginDragDropTarget () then
-                    if not (NativePtr.isNullPtr (ImGui.AcceptDragDropPayload "Entity").NativePtr) then
+                    if NativePtr.notNullPtr (ImGui.AcceptDragDropPayload "Entity").NativePtr then
                         match DragDropPayloadOpt with
                         | Some (DragDropEntity sourceEntity) ->
                             if sourceEntity.GetProtection world = Unprotected then
@@ -3155,7 +3155,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
                         with _ ->
                             Pasts <- pasts
                     if isPropertyAssetTag && ImGui.BeginDragDropTarget () then
-                        if not (NativePtr.isNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr) then
+                        if NativePtr.notNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr then
                             match DragDropPayloadOpt with
                             | Some (DragDropAsset (assetTagStr, _)) ->
                                 let pasts = Pasts

--- a/Nu/Nu.targets
+++ b/Nu/Nu.targets
@@ -291,8 +291,8 @@
 
         <!-- Embed splash SVG and color as embedded resources (read at runtime via SDL_IOFromConstMem) -->
         <ItemGroup>
-            <EmbeddedResource Include="@(MauiSplashScreen)" LogicalName="MauiSplash" />
-            <EmbeddedResource Condition="'%(MauiSplashScreen.Color)' != ''" Include="$(_SplashColorFile)" LogicalName="MauiSplashColor" />
+            <EmbeddedResource Include="@(MauiSplashScreen)" LogicalName="PreSplash" />
+            <EmbeddedResource Condition="'%(MauiSplashScreen.Color)' != ''" Include="$(_SplashColorFile)" LogicalName="PreSplashColor" />
         </ItemGroup>
     </Target>
 

--- a/Nu/Nu.targets
+++ b/Nu/Nu.targets
@@ -239,6 +239,9 @@
         <Error Condition="@(MauiIcon->Count()) > 1" Text="Multiple &lt;MauiIcon&gt; items were found. Please only specify one for desktop icon generation." />
         <Error Condition="'%(MauiIcon.Resize)' != ''" Text="The &lt;MauiIcon&gt; item should not specify the Resize attribute; only Include and ForegroundFile are supported for desktop icon generation." />
         <Error Condition="'%(MauiIcon.BaseSize)' != ''" Text="The &lt;MauiIcon&gt; item should not specify the BaseSize attribute; only Include and ForegroundFile are supported for desktop icon generation." />
+        <Error Condition="'%(MauiIcon.TintColor)' != ''" Text="The &lt;MauiIcon&gt; item should not specify the TintColor attribute; only Include and ForegroundFile are supported for desktop icon generation." />
+        <Error Condition="'%(MauiIcon.Color)' != ''" Text="The &lt;MauiIcon&gt; item should not specify the Color attribute; only Include and ForegroundFile are supported for desktop icon generation." />
+        <Error Condition="'%(MauiIcon.ForegroundScale)' != ''" Text="The &lt;MauiIcon&gt; item should not specify the ForegroundScale attribute; only Include and ForegroundFile are supported for desktop icon generation." />
 
         <!-- Use RuntimeIdentifier to determine target OS for cross-compilation (e.g. publishing Linux on macOS); fall
 		     back to the host OS when no RID is set (plain dotnet build). -->
@@ -266,6 +269,31 @@
             <Content Include="$(_DesktopIconDir)/app.png" Link="app.png" CopyToOutputDirectory="PreserveNewest" />
         </ItemGroup>
 		
+    </Target>
+
+    <!-- ============================================================
+         Desktop: Splash Screen Generation (from <MauiSplashScreen> SVG)
+         ============================================================ -->
+
+    <!-- Generate splash screen -->
+    <Target Name="GenerateDesktopSplash" BeforeTargets="BeforeBuild" Condition="'$(TargetPlatformIdentifier)' == '' And '@(MauiSplashScreen)' != ''">
+        <PropertyGroup>
+            <_SplashColorFile>$(IntermediateOutputPath)splash/SplashColor.txt</_SplashColorFile>
+        </PropertyGroup>
+        <Error Condition="@(MauiSplashScreen->Count()) > 1" Text="Multiple &lt;MauiSplashScreen&gt; items were found. Please only specify one for desktop splash generation." />
+        <Error Condition="'%(MauiSplashScreen.Resize)' != ''" Text="The &lt;MauiSplashScreen&gt; item should not specify the Resize attribute; only Include and Color are supported for desktop splash generation." />
+        <Error Condition="'%(MauiSplashScreen.BaseSize)' != ''" Text="The &lt;MauiSplashScreen&gt; item should not specify the BaseSize attribute; only Include and Color are supported for desktop splash generation." />
+        <Error Condition="'%(MauiSplashScreen.TintColor)' != ''" Text="The &lt;MauiSplashScreen&gt; item should not specify the TintColor attribute; only Include and Color are supported for desktop splash generation." />
+        <Error Condition="'%(MauiSplashScreen.ForegroundScale)' != ''" Text="The &lt;MauiSplashScreen&gt; item should not specify the ForegroundScale attribute; only Include and Color are supported for desktop splash generation." />
+        
+        <!-- Write the background color to a text file for runtime use -->
+        <WriteLinesToFile Condition="'%(MauiSplashScreen.Color)' != ''" File="$(_SplashColorFile)" Lines="%(MauiSplashScreen.Color)" Overwrite="true" />
+
+        <!-- Embed splash SVG and color as embedded resources (read at runtime via SDL_IOFromConstMem) -->
+        <ItemGroup>
+            <EmbeddedResource Include="@(MauiSplashScreen)" LogicalName="Splash.svg" />
+            <EmbeddedResource Condition="'%(MauiSplashScreen.Color)' != ''" Include="$(_SplashColorFile)" LogicalName="SplashColor.txt" />
+        </ItemGroup>
     </Target>
 
     <!-- ============================================================

--- a/Nu/Nu.targets
+++ b/Nu/Nu.targets
@@ -291,8 +291,8 @@
 
         <!-- Embed splash SVG and color as embedded resources (read at runtime via SDL_IOFromConstMem) -->
         <ItemGroup>
-            <EmbeddedResource Include="@(MauiSplashScreen)" LogicalName="Splash.svg" />
-            <EmbeddedResource Condition="'%(MauiSplashScreen.Color)' != ''" Include="$(_SplashColorFile)" LogicalName="SplashColor.txt" />
+            <EmbeddedResource Include="@(MauiSplashScreen)" LogicalName="MauiSplash" />
+            <EmbeddedResource Condition="'%(MauiSplashScreen.Color)' != ''" Include="$(_SplashColorFile)" LogicalName="MauiSplashColor" />
         </ItemGroup>
     </Target>
 

--- a/Nu/Nu/Core/Native.fs
+++ b/Nu/Nu/Core/Native.fs
@@ -19,6 +19,10 @@ module NativePtr =
           Size : int
           VoidPtr : voidptr }
 
+    /// Tests whether the given native ptr is not null.
+    let notNullPtr ptr =
+        not (NativePtr.isNullPtr ptr)
+
     /// Convert a managed pointer to a typed native pointer.
     let asPointer<'a when 'a : unmanaged> (managedPtr : byref<'a>) : nativeptr<'a> =
         let voidPtr = Unsafe.AsPointer<'a> &managedPtr

--- a/Nu/Nu/Cursor/CursorClient.fs
+++ b/Nu/Nu/Cursor/CursorClient.fs
@@ -123,13 +123,13 @@ type [<ReferenceEquality>] SdlCursorClient =
         | CursorExtension _ ->
             let filePathSdl = PathF.GetFullPath asset.FilePath
             let surface = SDL3_image.IMG_Load filePathSdl
-            if not (NativePtr.isNullPtr surface) then
+            if NativePtr.notNullPtr surface then
 
                 // create cursor. hotspot parameters (0, 0) here are overridden by the surface properties
                 // SDL_PROP_SURFACE_HOTSPOT_X_NUMBER and SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER set by Image.Load
                 let cursor = SDL3.SDL_CreateColorCursor (surface, 0, 0)
                 SDL3.SDL_DestroySurface surface // the cursor stores a copy of the frame data, the surface can be destroyed here
-                if not (NativePtr.isNullPtr cursor)
+                if NativePtr.notNullPtr cursor
                 then Some cursor
                 else
                     Log.warn ("Could not create cursor for '" + filePathSdl + "' due to: '" + SDL3.SDL_GetError ())
@@ -195,7 +195,7 @@ type [<ReferenceEquality>] SdlCursorClient =
         | Some cursor -> SDL3.SDL_SetCursor cursor
         | None ->
             let cursor = SDL3.SDL_CreateSystemCursor systemCursor
-            if not (NativePtr.isNullPtr cursor) then
+            if NativePtr.notNullPtr cursor then
                 cursorClient.SystemCursors[systemCursor] <- cursor
                 SDL3.SDL_SetCursor cursor
             else Log.warn ("Failed to create system cursor '" + scstring systemCursor + "' due to: " + SDL3.SDL_GetError ()); true

--- a/Nu/Nu/OpenGL/OpenGL.Texture.fs
+++ b/Nu/Nu/OpenGL/OpenGL.Texture.fs
@@ -546,7 +546,7 @@ module Texture =
                 let format = SDL_PixelFormat.SDL_PIXELFORMAT_ARGB8888 // seems to be the right format on Ubuntu...
                 let filePathSdl = PathF.GetFullPath filePath
                 let unconvertedPtr = SDL3_image.IMG_Load filePathSdl
-                if not (NativePtr.isNullPtr unconvertedPtr) then
+                if NativePtr.notNullPtr unconvertedPtr then
                     let unconverted = NativePtr.toByRef unconvertedPtr
                     let metadata = TextureMetadata.make unconverted.w unconverted.h
                     if unconverted.format <> format then

--- a/Nu/Nu/Render/Renderer2d.fs
+++ b/Nu/Nu/Render/Renderer2d.fs
@@ -821,7 +821,7 @@ type [<ReferenceEquality>] VulkanRenderer2d =
                                         (offset, textSurfacePtr)
 
                                 // render only when a valid surface was created
-                                if not (NativePtr.isNullPtr textSurfacePtr) then
+                                if NativePtr.notNullPtr textSurfacePtr then
                                     let textSurface = NativePtr.toByRef textSurfacePtr
 
                                     // construct mvp matrix

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -183,18 +183,18 @@ module SdlDeps =
         | None -> ()
         sdlDeps
 
-    /// Attempt to show a desktop splash screen on the given window from embedded SVG and color resources.
-    /// This renders the splash immediately using SDL's software surface API, before Vulkan takes over.
-    /// The splash will be overwritten when Vulkan presents its first swapchain image.
-    let private tryShowSplashScreen (window : SDL_Window nativeptr) =
+    /// Attempt to show a desktop pre-splash screen on the given window from embedded SVG and color resources. This
+    /// renders the pre-splash immediately using SDL's software surface API, before Vulkan takes over. The pre-splash
+    /// render will be overwritten when Vulkan presents its first swapchain image.
+    let private tryRenderPreSplash (window : SDL_Window nativeptr) =
 
-        // attempt to utilize splash graphics from manifest resource
+        // attempt to utilize pre-splash graphics from manifest resource
         let assembly = Assembly.GetEntryAssembly ()
-        let splashStreamOpt = assembly.GetManifestResourceStream "MauiSplash"
-        if notNull splashStreamOpt then
+        let svgStreamOpt = assembly.GetManifestResourceStream "PreSplash"
+        if notNull svgStreamOpt then
 
             // attempt to copy svg to memory
-            use svgStream = splashStreamOpt
+            use svgStream = svgStreamOpt
             let nativeMemory = NativeMemory.Alloc (unativeint svgStream.Length)
             try let nativeMemoryBytePtr = NativePtr.ofVoidPtr<byte> nativeMemory
                 use nativeStream = new UnmanagedMemoryStream (nativeMemoryBytePtr, svgStream.Length, svgStream.Length, FileAccess.Write)
@@ -218,17 +218,17 @@ module SdlDeps =
                             finally SDL3.SDL_DestroySurface rasterImage
                     finally SDL3.SDL_CloseIO svgStream |> ignore<SDLBool>
 
-                // attempt to populate window background with splash graphics
+                // attempt to populate window background with pre-splash graphics
                 try if NativePtr.notNullPtr surfacePtrOpt then
 
-                        // attempt to fill window background with splash color
+                        // attempt to fill window background with pre-splash color
                         let windowSurfacePtr = SDL3.SDL_GetWindowSurface window
-                        let splashColorStreamOpt = assembly.GetManifestResourceStream "MauiSplashColor"
-                        if notNull splashColorStreamOpt then
-                            use colorReader = new StreamReader (splashColorStreamOpt)
+                        let colorStreamOpt = assembly.GetManifestResourceStream "PreSplashColor"
+                        if notNull colorStreamOpt then
+                            use colorReader = new StreamReader (colorStreamOpt)
                             let colorStr = colorReader.ReadToEnd ()
-                            let colorParsed = Drawing.ColorTranslator.FromHtml colorStr // NOTE: this works fine starting on .NET Core 3.0.
-                            let color = SDL3.SDL_MapSurfaceRGBA (windowSurfacePtr, byte colorParsed.R, byte colorParsed.G, byte colorParsed.B, 255uy)
+                            let colorDrawing = Drawing.ColorTranslator.FromHtml colorStr // NOTE: this works fine starting on .NET Core 3.0.
+                            let color = SDL3.SDL_MapSurfaceRGBA (windowSurfacePtr, byte colorDrawing.R, byte colorDrawing.G, byte colorDrawing.B, 255uy)
                             SDL3.SDL_FillSurfaceRect (windowSurfacePtr, NativePtr.nullPtr, color) |> ignore<SDLBool>
 
                         // display splash screen centered on window
@@ -296,7 +296,7 @@ module SdlDeps =
                             SDL3.SDL_SetWindowFullscreen (window, true) |> ignore<SDLBool>
 
                         // attempt to show splash screen (software surface; will be overwritten by Vulkan)
-                        tryShowSplashScreen window
+                        tryRenderPreSplash window
 
                     // fin
                     windowOpt)

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -193,7 +193,7 @@ module SdlDeps =
     /// The splash will be overwritten when Vulkan presents its first swapchain image.
     let private tryShowSplashScreen (window : SDL_Window nativeptr) =
         let assembly = Assembly.GetEntryAssembly ()
-        let svgStream = assembly.GetManifestResourceStream "Splash.svg"
+        let svgStream = assembly.GetManifestResourceStream "MauiSplash"
         if not (isNull svgStream) then
             use svgStream = svgStream
             let nativeMemory = NativeMemory.Alloc (unativeint svgStream.Length)
@@ -203,13 +203,27 @@ module SdlDeps =
             let sdlStream = SDL3.SDL_IOFromConstMem (NativePtr.toNativeInt nativeMemoryBytePtr, unativeint svgStream.Length)
             let mutable w, h = 0, 0
             SDL3.SDL_GetWindowSizeInPixels (window, &&w, &&h) |> ignore<SDLBool>
-            let svgSurfacePtr = SDL3_image.IMG_LoadSizedSVG_IO (sdlStream, w, h)
-            SDL3.SDL_CloseIO sdlStream |> ignore<SDLBool>
+            let svgSurfacePtr =
+                if SDL3_image.IMG_isSVG sdlStream |> SDLBool.op_Implicit then
+                    // IMG_LoadSizedSVG_IO maintains aspect ratio automatically
+                    let vectorImage = SDL3_image.IMG_LoadSizedSVG_IO (sdlStream, w, h)
+                    SDL3.SDL_CloseIO sdlStream |> ignore<SDLBool>
+                    vectorImage
+                else
+                    // manually maintain aspect ratio for non-SVG images
+                    let rasterImage = SDL3_image.IMG_Load_IO (sdlStream, true)
+                    let rasterSurface = NativePtr.toByRef rasterImage
+                    let scaleX, scaleY = double w / double rasterSurface.w, double h / double rasterSurface.h
+                    let scale = min scaleX scaleY
+                    let newW, newH = int (double rasterSurface.w * scale), int (double rasterSurface.h * scale)
+                    let scaledImage = SDL3.SDL_ScaleSurface (rasterImage, newW, newH, SDL_ScaleMode.SDL_SCALEMODE_LINEAR)
+                    SDL3.SDL_DestroySurface rasterImage
+                    scaledImage
             if not (NativePtr.isNullPtr svgSurfacePtr) then
                 let windowSurfacePtr = SDL3.SDL_GetWindowSurface window
 
                 // fill window background with splash color
-                let colorStream = assembly.GetManifestResourceStream "SplashColor.txt"
+                let colorStream = assembly.GetManifestResourceStream "MauiSplashColor"
                 if not (isNull colorStream) then
                     use colorReader = new System.IO.StreamReader (colorStream)
                     let colorStr = colorReader.ReadToEnd ()

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -7,6 +7,7 @@
 namespace Nu
 open System
 open System.Collections.Generic
+open System.IO
 open System.Numerics
 open System.Reflection
 open System.Runtime.InteropServices
@@ -182,64 +183,68 @@ module SdlDeps =
         | None -> ()
         sdlDeps
 
-    /// An empty SdlDeps.
-    let empty =
-        { WindowOpt = None
-          Config = SdlConfig.defaultConfig
-          Destroy = id }
-
     /// Attempt to show a desktop splash screen on the given window from embedded SVG and color resources.
     /// This renders the splash immediately using SDL's software surface API, before Vulkan takes over.
     /// The splash will be overwritten when Vulkan presents its first swapchain image.
     let private tryShowSplashScreen (window : SDL_Window nativeptr) =
+
+        // attempt to utilize splash graphics from manifest resource
         let assembly = Assembly.GetEntryAssembly ()
-        let svgStream = assembly.GetManifestResourceStream "MauiSplash"
-        if not (isNull svgStream) then
-            use svgStream = svgStream
+        let splashStreamOpt = assembly.GetManifestResourceStream "MauiSplash"
+        if notNull splashStreamOpt then
+
+            // attempt to copy svg to memory
+            use svgStream = splashStreamOpt
             let nativeMemory = NativeMemory.Alloc (unativeint svgStream.Length)
-            let nativeMemoryBytePtr = NativePtr.ofVoidPtr<byte> nativeMemory
-            use nativeStream = new System.IO.UnmanagedMemoryStream (nativeMemoryBytePtr, svgStream.Length, svgStream.Length, System.IO.FileAccess.Write)
-            svgStream.CopyTo nativeStream
-            let sdlStream = SDL3.SDL_IOFromConstMem (NativePtr.toNativeInt nativeMemoryBytePtr, unativeint svgStream.Length)
-            let mutable w, h = 0, 0
-            SDL3.SDL_GetWindowSizeInPixels (window, &&w, &&h) |> ignore<SDLBool>
-            let svgSurfacePtr =
-                if SDL3_image.IMG_isSVG sdlStream |> SDLBool.op_Implicit then
-                    // IMG_LoadSizedSVG_IO maintains aspect ratio automatically
-                    let vectorImage = SDL3_image.IMG_LoadSizedSVG_IO (sdlStream, w, h)
-                    SDL3.SDL_CloseIO sdlStream |> ignore<SDLBool>
-                    vectorImage
-                else
-                    // manually maintain aspect ratio for non-SVG images
-                    let rasterImage = SDL3_image.IMG_Load_IO (sdlStream, true)
-                    let rasterSurface = NativePtr.toByRef rasterImage
-                    let scaleX, scaleY = double w / double rasterSurface.w, double h / double rasterSurface.h
-                    let scale = min scaleX scaleY
-                    let newW, newH = int (double rasterSurface.w * scale), int (double rasterSurface.h * scale)
-                    let scaledImage = SDL3.SDL_ScaleSurface (rasterImage, newW, newH, SDL_ScaleMode.SDL_SCALEMODE_LINEAR)
-                    SDL3.SDL_DestroySurface rasterImage
-                    scaledImage
-            if not (NativePtr.isNullPtr svgSurfacePtr) then
-                let windowSurfacePtr = SDL3.SDL_GetWindowSurface window
+            try let nativeMemoryBytePtr = NativePtr.ofVoidPtr<byte> nativeMemory
+                use nativeStream = new UnmanagedMemoryStream (nativeMemoryBytePtr, svgStream.Length, svgStream.Length, FileAccess.Write)
+                svgStream.CopyTo nativeStream
 
-                // fill window background with splash color
-                let colorStream = assembly.GetManifestResourceStream "MauiSplashColor"
-                if not (isNull colorStream) then
-                    use colorReader = new System.IO.StreamReader (colorStream)
-                    let colorStr = colorReader.ReadToEnd ()
-                    let colorParsed = Drawing.ColorTranslator.FromHtml colorStr
-                    let color = SDL3.SDL_MapSurfaceRGBA (windowSurfacePtr, byte colorParsed.R, byte colorParsed.G, byte colorParsed.B, 255uy)
-                    SDL3.SDL_FillSurfaceRect (windowSurfacePtr, NativePtr.nullPtr, color) |> ignore<SDLBool>
+                // attempt to copy memory to window surface with optional scaling
+                let mutable (windowWidth, windowHeight) = (0, 0)
+                SDL3.SDL_GetWindowSizeInPixels (window, &&windowWidth, &&windowHeight) |> ignore<SDLBool>
+                let svgStream = SDL3.SDL_IOFromConstMem (NativePtr.toNativeInt nativeMemoryBytePtr, unativeint svgStream.Length)
+                let surfacePtrOpt =
+                    try if SDL3_image.IMG_isSVG svgStream |> SDLBool.op_Implicit
+                        then SDL3_image.IMG_LoadSizedSVG_IO (svgStream, windowWidth, windowHeight) // maintains aspect ratio automatically
+                        else
+                            let rasterImage = SDL3_image.IMG_Load_IO (svgStream, true) // manually maintain aspect ratio for non-SVG images
+                            try let rasterSurface = NativePtr.toByRef rasterImage
+                                let (scaleX, scaleY) = (double windowWidth / double rasterSurface.w, double windowHeight / double rasterSurface.h)
+                                let scale = min scaleX scaleY
+                                let (newW, newH) = (int (double rasterSurface.w * scale), int (double rasterSurface.h * scale))
+                                let scaledImage = SDL3.SDL_ScaleSurface (rasterImage, newW, newH, SDL_ScaleMode.SDL_SCALEMODE_LINEAR)
+                                scaledImage
+                            finally SDL3.SDL_DestroySurface rasterImage
+                    finally SDL3.SDL_CloseIO svgStream |> ignore<SDLBool>
 
-                // display splash screen centered on window
-                let svgSurface = NativePtr.toByRef svgSurfacePtr
-                let mutable dstRect = SDL_Rect (x = (w - svgSurface.w) / 2, y = (h - svgSurface.h) / 2, w = svgSurface.w, h = svgSurface.h)
-                SDL3.SDL_BlitSurface (svgSurfacePtr, NativePtr.nullPtr, windowSurfacePtr, &&dstRect) |> ignore<SDLBool>
-                SDL3.SDL_UpdateWindowSurface window |> ignore<SDLBool>
-                SDL3.SDL_DestroySurface svgSurfacePtr
-            else
-                Log.warn ("Failed to load splash SVG from embedded resource: " + SDL3.SDL_GetError ())
-            NativeMemory.Free nativeMemory
+                // attempt to populate window background with splash graphics
+                try if NativePtr.notNullPtr surfacePtrOpt then
+
+                        // attempt to fill window background with splash color
+                        let windowSurfacePtr = SDL3.SDL_GetWindowSurface window
+                        let splashColorStreamOpt = assembly.GetManifestResourceStream "MauiSplashColor"
+                        if notNull splashColorStreamOpt then
+                            use colorReader = new StreamReader (splashColorStreamOpt)
+                            let colorStr = colorReader.ReadToEnd ()
+                            let colorParsed = Drawing.ColorTranslator.FromHtml colorStr // NOTE: this works fine starting on .NET Core 3.0.
+                            let color = SDL3.SDL_MapSurfaceRGBA (windowSurfacePtr, byte colorParsed.R, byte colorParsed.G, byte colorParsed.B, 255uy)
+                            SDL3.SDL_FillSurfaceRect (windowSurfacePtr, NativePtr.nullPtr, color) |> ignore<SDLBool>
+
+                        // display splash screen centered on window
+                        let svgSurface = NativePtr.toByRef surfacePtrOpt
+                        let mutable dstRect = SDL_Rect (x = (windowWidth - svgSurface.w) / 2, y = (windowHeight - svgSurface.h) / 2, w = svgSurface.w, h = svgSurface.h)
+                        SDL3.SDL_BlitSurface (surfacePtrOpt, NativePtr.nullPtr, windowSurfacePtr, &&dstRect) |> ignore<SDLBool>
+                        SDL3.SDL_UpdateWindowSurface window |> ignore<SDLBool>
+
+                    // log issue
+                    else Log.warn ("Failed to load splash SVG from embedded resource: " + SDL3.SDL_GetError ())
+
+                // clean-up
+                finally SDL3.SDL_DestroySurface surfacePtrOpt
+
+            // clean-up
+            finally NativeMemory.Free nativeMemory
 
     /// Attempt to make an SdlDeps instance.
     let tryMake (sdlConfig : SdlConfig) (accompanied : bool) (windowSize : Vector2i) =
@@ -275,7 +280,7 @@ module SdlDeps =
                     // attempt to create window
                     let windowConfig = sdlConfig.WindowConfig
                     let windowOpt = SDL3.SDL_CreateWindow (windowConfig.WindowTitle, windowSize.X, windowSize.Y, windowConfig.WindowFlags)
-                    if not (NativePtr.isNullPtr windowOpt) then
+                    if NativePtr.notNullPtr windowOpt then
 
                         // set window position
                         let window = windowOpt
@@ -313,6 +318,12 @@ module SdlDeps =
                              ".")
                         GamepadState.init ()
                         Right { WindowOpt = Some window; Config = sdlConfig; Destroy = destroy }
+
+    /// An empty SdlDeps.
+    let empty =
+        { WindowOpt = None
+          Config = SdlConfig.defaultConfig
+          Destroy = id }
 
 /// The dependencies needed to initialize SDL.
 type SdlDeps = SdlDeps.SdlDeps

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -202,7 +202,7 @@ module SdlDeps =
             svgStream.CopyTo nativeStream
             let sdlStream = SDL3.SDL_IOFromConstMem (NativePtr.toNativeInt nativeMemoryBytePtr, unativeint svgStream.Length)
             let mutable w, h = 0, 0
-            SDL3.SDL_GetWindowSize (window, &&w, &&h) |> ignore<SDLBool>
+            SDL3.SDL_GetWindowSizeInPixels (window, &&w, &&h) |> ignore<SDLBool>
             let svgSurfacePtr = SDL3_image.IMG_LoadSizedSVG_IO (sdlStream, w, h)
             SDL3.SDL_CloseIO sdlStream |> ignore<SDLBool>
             if not (NativePtr.isNullPtr svgSurfacePtr) then

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -188,6 +188,45 @@ module SdlDeps =
           Config = SdlConfig.defaultConfig
           Destroy = id }
 
+    /// Attempt to show a desktop splash screen on the given window from embedded SVG and color resources.
+    /// This renders the splash immediately using SDL's software surface API, before Vulkan takes over.
+    /// The splash will be overwritten when Vulkan presents its first swapchain image.
+    let private tryShowSplashScreen (window : SDL_Window nativeptr) =
+        let assembly = Assembly.GetEntryAssembly ()
+        let svgStream = assembly.GetManifestResourceStream "Splash.svg"
+        if not (isNull svgStream) then
+            use svgStream = svgStream
+            let nativeMemory = NativeMemory.Alloc (unativeint svgStream.Length)
+            let nativeMemoryBytePtr = NativePtr.ofVoidPtr<byte> nativeMemory
+            use nativeStream = new System.IO.UnmanagedMemoryStream (nativeMemoryBytePtr, svgStream.Length, svgStream.Length, System.IO.FileAccess.Write)
+            svgStream.CopyTo nativeStream
+            let sdlStream = SDL3.SDL_IOFromConstMem (NativePtr.toNativeInt nativeMemoryBytePtr, unativeint svgStream.Length)
+            let mutable w, h = 0, 0
+            SDL3.SDL_GetWindowSize (window, &&w, &&h) |> ignore<SDLBool>
+            let svgSurfacePtr = SDL3_image.IMG_LoadSizedSVG_IO (sdlStream, w, h)
+            SDL3.SDL_CloseIO sdlStream |> ignore<SDLBool>
+            if not (NativePtr.isNullPtr svgSurfacePtr) then
+                let windowSurfacePtr = SDL3.SDL_GetWindowSurface window
+
+                // fill window background with splash color
+                let colorStream = assembly.GetManifestResourceStream "SplashColor.txt"
+                if not (isNull colorStream) then
+                    use colorReader = new System.IO.StreamReader (colorStream)
+                    let colorStr = colorReader.ReadToEnd ()
+                    let colorParsed = Drawing.ColorTranslator.FromHtml colorStr
+                    let color = SDL3.SDL_MapSurfaceRGBA (windowSurfacePtr, byte colorParsed.R, byte colorParsed.G, byte colorParsed.B, 255uy)
+                    SDL3.SDL_FillSurfaceRect (windowSurfacePtr, NativePtr.nullPtr, color) |> ignore<SDLBool>
+
+                // display splash screen centered on window
+                let svgSurface = NativePtr.toByRef svgSurfacePtr
+                let mutable dstRect = SDL_Rect (x = (w - svgSurface.w) / 2, y = (h - svgSurface.h) / 2, w = svgSurface.w, h = svgSurface.h)
+                SDL3.SDL_BlitSurface (svgSurfacePtr, NativePtr.nullPtr, windowSurfacePtr, &&dstRect) |> ignore<SDLBool>
+                SDL3.SDL_UpdateWindowSurface window |> ignore<SDLBool>
+                SDL3.SDL_DestroySurface svgSurfacePtr
+            else
+                Log.warn ("Failed to load splash SVG from embedded resource: " + SDL3.SDL_GetError ())
+            NativeMemory.Free nativeMemory
+
     /// Attempt to make an SdlDeps instance.
     let tryMake (sdlConfig : SdlConfig) (accompanied : bool) (windowSize : Vector2i) =
         match attemptPerformSdlInit
@@ -236,6 +275,9 @@ module SdlDeps =
                         let mutable displayMode = getDisplayModeInternal window
                         if (windowSize.X = displayMode.w || windowSize.Y = displayMode.h) && not accompanied then
                             SDL3.SDL_SetWindowFullscreen (window, true) |> ignore<SDLBool>
+
+                        // attempt to show splash screen (software surface; will be overwritten by Vulkan)
+                        tryShowSplashScreen window
 
                     // fin
                     windowOpt)

--- a/Nu/Nu/Vulkan/VulkanTexture.fs
+++ b/Nu/Nu/Vulkan/VulkanTexture.fs
@@ -977,7 +977,7 @@ module TextureModule2 =
                     let format = SDL_PixelFormat.SDL_PIXELFORMAT_ARGB8888 // seems to be the right format on Ubuntu...
                     let filePathSdl = PathF.GetFullPath filePath
                     let unconvertedPtr = SDL3_image.IMG_Load filePathSdl
-                    if not (NativePtr.isNullPtr unconvertedPtr) then
+                    if NativePtr.notNullPtr unconvertedPtr then
                         let unconverted = NativePtr.toByRef unconvertedPtr
                         let metadata = TextureMetadata.make unconverted.w unconverted.h
                         if unconverted.format <> format then

--- a/Nu/Nu/World/WorldImGui.fs
+++ b/Nu/Nu/World/WorldImGui.fs
@@ -530,7 +530,7 @@ module WorldImGui =
                     let (edited3, value) =
                         if ImGui.BeginDragDropTarget () then
                             let (edited4, value) =
-                                if not (NativePtr.isNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr) then
+                                if NativePtr.notNullPtr (ImGui.AcceptDragDropPayload "Asset").NativePtr then
                                     match context.DragDropPayloadOpt with
                                     | Some (DragDropAsset (assetTagStr, _)) ->
                                         try let valueStrEscaped = assetTagStr

--- a/Projects/Mobile/Mobile.fsproj
+++ b/Projects/Mobile/Mobile.fsproj
@@ -55,9 +55,6 @@
 	<ItemGroup>
 		<None Include="Assets\*" />
 		<None Include="Assets\*\*" />
-		<None Include="App\iOS Info.plist">
-			<LogicalName>Info.plist</LogicalName>
-		</None>
 		<Compile Include="Assets.fs" />
 		<Compile Include="Simulants.fs" />
 		<Compile Include="Gameplay.fs" />
@@ -79,9 +76,10 @@
              and Assets.xcassets/icon_bg.appiconset in "App/iOS Info.plist". -->
 		<MauiIcon Include="App/icon_bg.svg" ForegroundFile="App/icon_fg.svg" />
 		<!-- Splash screen with background color: https://learn.microsoft.com/en-us/dotnet/maui/user-interface/images/splashscreen
-             Only applicable to mobile. -->
+             On desktop, Nu.targets embeds the splash screen for display on startup. -->
 		<MauiSplashScreen Include="App/icon_fg.svg" Color="#512BD4" />
 		<!-- iOS Information property list: https://learn.microsoft.com/en-us/dotnet/maui/macios/info-plist -->
+		<None Include="App/iOS Info.plist" LogicalName="Info.plist" />
 		<!-- iOS Privacy manifest: https://learn.microsoft.com/en-us/dotnet/maui/ios/privacy-manifest -->
 		<BundleResource Include="App/iOS PrivacyInfo.xcprivacy" LogicalName="PrivacyInfo.xcprivacy" />
 		<!-- macOS Information property list template, only applicable to "dotnet publish" that creates a macOS .app bundle -->


### PR DESCRIPTION
Not the fake splash screen that only displays after a black screen waiting for the renderer to load.

Only applies to projects that specify `<MauiSplashScreen>` i.e. Mobile.