### PR TITLE
Fix entityStateSetter accessibility

### DIFF
--- a/Nu/Nu/World/WorldModuleEntity.fs
+++ b/Nu/Nu/World/WorldModuleEntity.fs
@@ -140,7 +140,7 @@ module WorldModuleEntity =
             let entityStates = SUMap.remove entity world.EntityStates
             world.WorldState <- { world.WorldState with Simulants = simulants; EntityStates = entityStates }
 
-        static member private entityStateSetter entityState (entity : Entity) (world : World) =
+        static member internal entityStateSetter entityState (entity : Entity) (world : World) =
 #if DEBUG
             if not (SUMap.containsKey entity world.EntityStates) then
                 failwith ("Cannot set the state of a non-existent entity '" + scstring entity + "'")


### PR DESCRIPTION
Fixes a runtime access rights exception when compiled with `realsig+` or without inlinling (https://github.com/dotnet/fsharp/pull/19548#issuecomment-4851990866).