### PR TITLE
entityStateSetter: private -> internal

### DIFF
--- a/Nu/Nu/World/WorldModuleEntity.fs
+++ b/Nu/Nu/World/WorldModuleEntity.fs
@@ -140,7 +140,7 @@ module WorldModuleEntity =
             let entityStates = SUMap.remove entity world.EntityStates
             world.WorldState <- { world.WorldState with Simulants = simulants; EntityStates = entityStates }
 
-        static member private entityStateSetter entityState (entity : Entity) (world : World) =
+        static member internal entityStateSetter entityState (entity : Entity) (world : World) =
 #if DEBUG
             if not (SUMap.containsKey entity world.EntityStates) then
                 failwith ("Cannot set the state of a non-existent entity '" + scstring entity + "'")


### PR DESCRIPTION
`setEntityState` is `inline internal` and calls `entityStateSetter` (`private`). `inline` copies that call into callers in other types (`Entity.SetBoneTransformsFast` in `WorldFacets.fs`, `WorldModule2.fs`); under `--realsig+` a `private` callee is IL-private, so those sites throw `MethodAccessException`. Widen to `internal` — only `setEntityState` references it.

Spotted via the dotnet/fsharp regression-testing suite (Nu is one of the tracked projects): an inline+accessibility bugfix in the F# compiler started reporting this as an error.
