### PR TITLE
feat: guard viewport synchronization during resize

### DIFF
--- a/Nu/Nu.Gaia/Gaia.fs
+++ b/Nu/Nu.Gaia/Gaia.fs
@@ -902,7 +902,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
         if entity.GetIs2d world then
             let absolute = entity.GetAbsolute world
             let entityPosition =
-                if atMouse then Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize RightClickPosition world.WindowViewport
+                if atMouse then Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed RightClickPosition world.WindowViewport
                 elif not absolute then world.Eye2dCenter
                 else v2Zero
             entityTransform.Position <- entityPosition.V3
@@ -1591,7 +1591,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
                     if entity.GetIs2d world then
                         if World.isKeyboardAltDown world then
                             let absolute = entity.GetAbsolute world
-                            let mousePositionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize mousePosition world.WindowViewport
+                            let mousePositionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed mousePosition world.WindowViewport
                             let entityDegrees = if entity.MountExists world then entity.GetDegreesLocal world else entity.GetDegrees world
                             DragEntityState <- DragEntityRotation2d (world.DateTime, ref false, mousePositionWorld, entityDegrees.Z + mousePositionWorld.Y, entity)
                         else
@@ -1622,7 +1622,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
                                     duplicate
                                 else entity
                             let absolute = entity.GetAbsolute world
-                            let mousePositionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize mousePosition world.WindowViewport
+                            let mousePositionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed mousePosition world.WindowViewport
                             let entityPosition = entity.GetPosition world
                             DragEntityState <- DragEntityPosition2d (world.DateTime, ref false, mousePositionWorld, entityPosition.V2 + mousePositionWorld, entity)
                 | None -> ()
@@ -4537,7 +4537,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
             File.WriteAllText (imguiIniFilePath, ImGuiIniFileStr)
 
         // attempt to create SDL dependencies
-        let windowSize = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
+        let windowSize = Globals.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
         let windowViewport = Viewport.makeWindow1 windowSize
         let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
         match tryMakeSdlDeps true windowSize with

--- a/Nu/Nu.Tests/WorldTests.fs
+++ b/Nu/Nu.Tests/WorldTests.fs
@@ -12,6 +12,105 @@ open Nu
 open Nu.Tests
 module WorldTests =
 
+    let private makeStubWorld () =
+        Nu.init ()
+        World.makeStub (constant None) { WorldConfig.defaultConfig with Accompanied = true } (TestPlugin ())
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution synchronizes world state immediately.`` () =
+        let previousResolution = Globals.Render.DisplayVirtualResolution
+        let previousScalar = Globals.Render.DisplayScalar
+        try
+            let world = makeStubWorld ()
+            let eyeSizePrevious = world.Eye2dSize
+            let resolution = System.Numerics.Vector2i (800, 600)
+            World.setDisplayVirtualResolution resolution world
+            Assert.Equal (resolution, World.getDisplayVirtualResolution ())
+            Assert.Equal (eyeSizePrevious, world.Eye2dSize)
+            Assert.Equal (Globals.Render.DisplayScalar, world.WindowViewport.DisplayScalar)
+            let geometryBounds = System.Numerics.Box2i (System.Numerics.Vector2i.Zero, world.GeometryViewport.Bounds.Size)
+            let expectedViewport =
+                Viewport.make
+                    Constants.Render.NearPlaneDistanceInterior
+                    Constants.Render.FarPlaneDistanceInterior
+                    geometryBounds
+                    geometryBounds
+                    geometryBounds
+            let expectedFrustum =
+                Viewport.getFrustum world.Eye3dCenter world.Eye3dRotation world.Eye3dFieldOfView expectedViewport
+            Assert.Equal (expectedFrustum, world.Eye3dFrustumInterior)
+        finally
+            Globals.Render.DisplayVirtualResolution <- previousResolution
+            Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution preserves custom eye size.`` () =
+        let previousResolution = Globals.Render.DisplayVirtualResolution
+        let previousScalar = Globals.Render.DisplayScalar
+        try
+            let world = makeStubWorld ()
+            let customEyeSize = System.Numerics.Vector2 (123.0f, 77.0f)
+            World.setEye2dSize customEyeSize world
+            World.setDisplayVirtualResolution (System.Numerics.Vector2i (800, 600)) world
+            Assert.Equal (customEyeSize, world.Eye2dSize)
+        finally
+            Globals.Render.DisplayVirtualResolution <- previousResolution
+            Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Invalid display virtual resolution leaves state unchanged.`` () =
+        let previousResolution = Globals.Render.DisplayVirtualResolution
+        let previousScalar = Globals.Render.DisplayScalar
+        try
+            let world = makeStubWorld ()
+            let eyeSize = world.Eye2dSize
+            Assert.Throws<ArgumentException> (fun () -> World.setDisplayVirtualResolution (System.Numerics.Vector2i (0, 450)) world |> ignore) |> ignore
+            Assert.Equal (previousResolution, Globals.Render.DisplayVirtualResolution)
+            Assert.Equal (eyeSize, world.Eye2dSize)
+        finally
+            Globals.Render.DisplayVirtualResolution <- previousResolution
+            Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution remains supported without an SDL display.`` () =
+        let previousResolution = Globals.Render.DisplayVirtualResolution
+        let previousScalar = Globals.Render.DisplayScalar
+        try
+            let world = makeStubWorld ()
+            World.setDisplayVirtualResolution (System.Numerics.Vector2i (2000, 1200)) world
+            Assert.Equal (System.Numerics.Vector2i (2000, 1200), World.getDisplayVirtualResolution ())
+        finally
+            Globals.Render.DisplayVirtualResolution <- previousResolution
+            Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Constrain eye bounds includes the visible eye margin.`` () =
+        let eyeMarginPrevious = Constants.Engine.EyeMarginMaxScalar
+        try
+            Constants.Engine.EyeMarginMaxScalar <- System.Numerics.Vector2 (0.5f, 0.5f)
+            let world = makeStubWorld ()
+            World.setEye2dSize (System.Numerics.Vector2 (100.0f, 100.0f)) world
+            World.setEye2dCenter (System.Numerics.Vector2 (450.0f, 0.0f)) world
+            let bounds = System.Numerics.Box2 (System.Numerics.Vector2 (-500.0f, -500.0f), System.Numerics.Vector2 (1000.0f, 1000.0f))
+            World.constrainEye2dBounds bounds world
+            Assert.That (world.Eye2dBoundsViewed.Min.X, Is.GreaterThanOrEqualTo bounds.Min.X)
+            Assert.That
+                (world.Eye2dBoundsViewed.Min.X + world.Eye2dBoundsViewed.Size.X,
+                 Is.LessThanOrEqualTo (bounds.Min.X + bounds.Size.X))
+        finally
+            Constants.Engine.EyeMarginMaxScalar <- eyeMarginPrevious
+
+    let [<Test; NonParallelizable>] ``Zero-sized viewport synchronization preserves drawable state.`` () =
+        let previousScalar = Globals.Render.DisplayScalar
+        try
+            let world = makeStubWorld ()
+            let emptyBounds = System.Numerics.Box2i (System.Numerics.Vector2i.Zero, System.Numerics.Vector2i.Zero)
+            World.setWindowViewport (Viewport.makeWindow emptyBounds emptyBounds System.Numerics.Vector2i.Zero) world
+            let viewportPrevious = world.WindowViewport
+            let geometryViewportPrevious = world.GeometryViewport
+            let frustumPrevious = world.Eye3dFrustumInterior
+            World.setEye2dSize (world.Eye2dSize + System.Numerics.Vector2.One) world
+            Assert.Equal (viewportPrevious, world.WindowViewport)
+            Assert.Equal (geometryViewportPrevious, world.GeometryViewport)
+            Assert.Equal (frustumPrevious, world.Eye3dFrustumInterior)
+        finally
+            Globals.Render.DisplayScalar <- previousScalar
+
     let [<Test>] ``Run empty frame then clean up.`` () =
         Nu.init ()
         let world = World.makeStub (constant None) { WorldConfig.defaultConfig with Accompanied = true } (TestPlugin ())
@@ -21,7 +120,7 @@ module WorldTests =
     let [<Test; Category "Integration">] ``Run integration frame then clean up.`` () =
         Nu.init ()
         let worldConfig = { WorldConfig.defaultConfig with Accompanied = true }
-        let windowSize = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
+        let windowSize = Globals.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
         match SdlDeps.tryMake worldConfig.SdlConfig false windowSize with
         | Right sdlDeps ->
             use _ = sdlDeps // bind explicitly to dispose automatically

--- a/Nu/Nu/Core/Constants.fs
+++ b/Nu/Nu/Core/Constants.fs
@@ -97,6 +97,9 @@ module Engine =
     let [<Uniform>] EntityGuiSizeDefault = Vector3 (128.0f, 32.0f, 0.0f)
     let [<Uniform>] Entity3dSizeDefault = Vector3 (1.0f, 1.0f, 1.0f)
     let [<Uniform>] EntityVuiSizeDefault = Vector3 (4.0f, 1.0f, 1.0f)
+    /// The 2d eye can extend up to (EyeMarginMaxScalar * Eye2dSize) on each side, so that the world can be rendered up to the edges of the window without being clipped.
+    let [<Uniform>] mutable EyeMarginMaxScalar =
+        Vector2.Max (v2Zero, match ConfigurationManager.AppSettings["EyeMarginMaxScalar"] with null -> v2Zero | value -> scvalue value)
     let [<Uniform>] Particle2dSizeDefault = Vector3 (4.0f, 4.0f, 0.0f)
     let [<Uniform>] Particle3dSizeDefault = Vector3 (0.25f, 0.25f, 0.25f)
     let [<Uniform>] BodyJoint2dSizeDefault = Vector3 (16.0f, 16.0f, 0.0f)
@@ -122,6 +125,7 @@ module Engine =
               "Protection"
               "Id"
               (* Game Properties *)
+              "Eye2dViewed"
               "Eye3dFrustumInterior"
               "Eye3dFrustumExterior"
               "Eye3dFrustumImposter"
@@ -199,7 +203,6 @@ module Render =
     let [<Uniform>] mutable FarPlaneDistanceImposter = match ConfigurationManager.AppSettings["FarPlaneDistanceImposter"] with null -> 4096.0f | value -> scvalue value
     let [<Uniform>] mutable NearPlaneDistanceOmnipresent = NearPlaneDistanceInterior
     let [<Uniform>] mutable FarPlaneDistanceOmnipresent = FarPlaneDistanceImposter
-    let [<Uniform>] mutable DisplayVirtualResolution = match ConfigurationManager.AppSettings["DisplayVirtualResolution"] with null -> v2i 640 360 | value -> scvalue value
     let [<Uniform>] mutable SsaoResolutionDivisor = match ConfigurationManager.AppSettings["SsaoResolutionDivisor"] with null -> 1 | value -> scvalue value
     let [<Uniform>] Play3dBoxSize = Vector3 64.0f
     let [<Uniform>] WindowClearColor = Color.Zero

--- a/Nu/Nu/Core/Globals.fs
+++ b/Nu/Nu/Core/Globals.fs
@@ -7,14 +7,18 @@
 namespace Nu.Globals
 open System
 open System.Configuration
+open System.Numerics
 open Prime
 
 /// Global mutable rendering values. Change tracking must be done manually by dependant code.
 [<RequireQualifiedAccess>]
 module Render =
 
+    /// The mutable display virtual resolution. Change it at runtime through World.setDisplayVirtualResolution.
+    let mutable DisplayVirtualResolution : Vector2i = match ConfigurationManager.AppSettings["DisplayVirtualResolution"] with null -> Vector2i (640, 360) | value -> scvalue value
+
     /// The global mutable display scalar. This may be changed by the engine at run-time.
-    let mutable DisplayScalar = match ConfigurationManager.AppSettings["DisplayScalar"] with null -> 2 | value -> scvalue value
+    let mutable DisplayScalar = max 1 (match ConfigurationManager.AppSettings["DisplayScalar"] with null -> 2 | value -> scvalue value)
 
     /// The global mutable shadow scalar. This may be changed by the engine at run-time.
     let mutable ShadowScalar = match ConfigurationManager.AppSettings["ShadowScalar"] with null -> 4 | value -> scvalue value

--- a/Nu/Nu/Sdl/SdlDeps.fs
+++ b/Nu/Nu/Sdl/SdlDeps.fs
@@ -182,7 +182,7 @@ module SdlDeps =
             // when changing from full screen, set window to windowed size and make sure its title bar is visible
             if  fullScreenChanged && wasFullScreen && not fullScreen &&
                 SDL3.SDL_SyncWindow window |> SDLBool.op_Implicit then
-                let windowSizeWindowed = Constants.Render.DisplayVirtualResolution * 2 // NOTE: hard-coded 2 means display scalar of size 2 is the default restore window size.
+                let windowSizeWindowed = Globals.Render.DisplayVirtualResolution * 2 // NOTE: hard-coded 2 means display scalar of size 2 is the default restore window size.
                 if  SDL3.SDL_RestoreWindow window |> SDLBool.op_Implicit &&
                     SDL3.SDL_SyncWindow window |> SDLBool.op_Implicit then
                     let pixelDensity = SDL3.SDL_GetWindowPixelDensity window // restoration can change the window's display, and therefore its pixel density

--- a/Nu/Nu/Transform/Viewport.fs
+++ b/Nu/Nu/Transform/Viewport.fs
@@ -253,22 +253,37 @@ type [<StructuralEquality; NoComparison>] Viewport =
         Viewport.make Constants.Render.NearPlaneDistanceOmnipresent Constants.Render.FarPlaneDistanceOmnipresent inner bounds outer
 
     static member makeWindow1 (windowSize : Vector2i) =
-        let boundsSize = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let boundsMin = Vector2i ((windowSize.X - boundsSize.X) / 2, (windowSize.Y - boundsSize.Y) / 2)
+        Viewport.makeWindowViewed Globals.Render.DisplayVirtualResolution.V2 windowSize
+
+    static member makeWindowViewed (eyeViewed : Vector2) (windowSize : Vector2i) =
+        let displayScalar = Globals.Render.DisplayScalar
+        let boundsSizeX = min (int (ceil (eyeViewed.X * single displayScalar))) windowSize.X
+        let boundsSizeY = min (int (ceil (eyeViewed.Y * single displayScalar))) windowSize.Y
+        let boundsSize = v2i boundsSizeX boundsSizeY
+        let boundsMin = (windowSize - boundsSize) / 2
         let bounds = box2i boundsMin boundsSize
         Viewport.makeWindow bounds bounds windowSize // presume inner = bounds
 
-    static member makeInterior () =
-        let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
+    static member makeInteriorViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
         Viewport.make Constants.Render.NearPlaneDistanceInterior Constants.Render.FarPlaneDistanceInterior bounds bounds bounds
 
-    static member makeExterior () =
-        let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
+    static member makeInterior () =
+        let outerResolution = Globals.Render.DisplayVirtualResolution * max 1 Globals.Render.DisplayScalar
+        Viewport.makeInteriorViewed outerResolution
+
+    static member makeExteriorViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
         Viewport.make Constants.Render.NearPlaneDistanceExterior Constants.Render.FarPlaneDistanceExterior bounds bounds bounds
 
-    static member makeImposter () =
-        let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
+    static member makeExterior () =
+        let outerResolution = Globals.Render.DisplayVirtualResolution * max 1 Globals.Render.DisplayScalar
+        Viewport.makeExteriorViewed outerResolution
+
+    static member makeImposterViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
         Viewport.make Constants.Render.NearPlaneDistanceImposter Constants.Render.FarPlaneDistanceImposter bounds bounds bounds
+
+    static member makeImposter () =
+        let outerResolution = Globals.Render.DisplayVirtualResolution * max 1 Globals.Render.DisplayScalar
+        Viewport.makeImposterViewed outerResolution

--- a/Nu/Nu/Vulkan/VulkanContour.fs
+++ b/Nu/Nu/Vulkan/VulkanContour.fs
@@ -192,9 +192,7 @@ module Contour =
                         let minClip = Vector4.Transform(Vector4 (clip.Min.X, clip.Max.Y, 0.0f, 1.0f), viewProjection).V2
                         let minNdc = minClip * single viewport.DisplayScalar
                         let minScissor = (minNdc + v2One) * 0.5f * viewport.Inner.Size.V2
-                        let sizeClip = Vector4.Transform(Vector4 (clip.Size, 0.0f, 1.0f), viewProjection).V2
-                        let sizeNdc = sizeClip * single viewport.DisplayScalar
-                        let sizeScissor = sizeNdc * 0.5f * viewport.Inner.Size.V2
+                        let sizeScissor = clip.Size * single viewport.DisplayScalar
                         let offset = v2i viewport.Inner.Min.X (viewport.Outer.Max.Y - viewport.Inner.Max.Y)
                         scissor <-
                             VkRect2D

--- a/Nu/Nu/Vulkan/VulkanSpriteBatch.fs
+++ b/Nu/Nu/Vulkan/VulkanSpriteBatch.fs
@@ -126,9 +126,7 @@ module SpriteBatch =
                 let minClip = Vector4.Transform(Vector4 (clip.Min.X, clip.Max.Y, 0.0f, 1.0f), viewProjection).V2
                 let minNdc = minClip * single viewport.DisplayScalar
                 let minScissor = (minNdc + v2One) * 0.5f * viewport.Inner.Size.V2
-                let sizeClip = Vector4.Transform(Vector4 (clip.Size, 0.0f, 1.0f), viewProjection).V2
-                let sizeNdc = sizeClip * single viewport.DisplayScalar
-                let sizeScissor = sizeNdc * 0.5f * viewport.Inner.Size.V2
+                let sizeScissor = clip.Size * single viewport.DisplayScalar
                 let offset = v2i viewport.Inner.Min.X (viewport.Outer.Max.Y - viewport.Inner.Max.Y)
                 scissor <-
                     VkRect2D

--- a/Nu/Nu/Vulkan/VulkanSpriteSingleton.fs
+++ b/Nu/Nu/Vulkan/VulkanSpriteSingleton.fs
@@ -113,9 +113,7 @@ module SpriteSingleton =
             let minClip = Vector4.Transform(Vector4 (clip.Min.X, clip.Max.Y, 0.0f, 1.0f), viewProjection).V2
             let minNdc = minClip * single viewport.DisplayScalar
             let minScissor = (minNdc + v2One) * 0.5f * viewport.Inner.Size.V2
-            let sizeClip = Vector4.Transform(Vector4 (clip.Size, 0.0f, 1.0f), viewProjection).V2
-            let sizeNdc = sizeClip * single viewport.DisplayScalar
-            let sizeScissor = sizeNdc * 0.5f * viewport.Inner.Size.V2
+            let sizeScissor = clip.Size * single viewport.DisplayScalar
             let offset = v2i viewport.Inner.Min.X (viewport.Outer.Max.Y - viewport.Inner.Max.Y)
             scissor <-
                 VkRect2D

--- a/Nu/Nu/World/World.fs
+++ b/Nu/Nu/World/World.fs
@@ -496,7 +496,7 @@ module WorldModule4 =
             let jobGraph = JobGraphInline ()
 
             // make the default viewports
-            let windowViewport = Viewport.makeWindow1 Constants.Render.DisplayVirtualResolution
+            let windowViewport = Viewport.makeWindow1 Globals.Render.DisplayVirtualResolution
             let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
 
             // make the world's late-bindings instances
@@ -670,7 +670,7 @@ module WorldModule4 =
         /// Run the game engine, initializing dependencies as indicated by WorldConfig, and returning exit code upon
         /// termination.
         static member run firstFrameCallback worldConfig plugin =
-            let windowSize = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
+            let windowSize = Globals.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
             let windowViewport = Viewport.makeWindow1 windowSize
             let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
             World.runPlus

--- a/Nu/Nu/World/WorldConfigure.fs
+++ b/Nu/Nu/World/WorldConfigure.fs
@@ -42,7 +42,8 @@ module Configure =
                 | nameof Constants.Render.FarPlaneDistanceExterior -> Constants.Render.FarPlaneDistanceExterior <- scvalue value
                 | nameof Constants.Render.NearPlaneDistanceImposter -> Constants.Render.NearPlaneDistanceImposter <- scvalue value
                 | nameof Constants.Render.FarPlaneDistanceImposter -> Constants.Render.FarPlaneDistanceImposter <- scvalue value
-                | nameof Constants.Render.DisplayVirtualResolution -> Constants.Render.DisplayVirtualResolution <- scvalue value
+                | nameof Constants.Engine.EyeMarginMaxScalar -> Constants.Engine.EyeMarginMaxScalar <- scvalue value
+                | nameof Globals.Render.DisplayVirtualResolution -> Globals.Render.DisplayVirtualResolution <- scvalue value
                 | nameof Constants.Render.SsaoResolutionDivisor -> Constants.Render.SsaoResolutionDivisor <- scvalue value
                 | nameof Constants.Render.TextureAnisotropyMax -> Constants.Render.TextureAnisotropyMax <- scvalue value
                 | nameof Constants.Render.TextureMinimalMipmapIndex -> Constants.Render.TextureMinimalMipmapIndex <- scvalue value

--- a/Nu/Nu/World/WorldEntity.fs
+++ b/Nu/Nu/World/WorldEntity.fs
@@ -733,7 +733,7 @@ module WorldEntityModule =
             Array.tryFind (fun (entity : Entity) ->
                 if entity.GetPickable world then
                     let absolute = entity.GetAbsolute world
-                    let positionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize position world.WindowViewport
+                    let positionWorld = Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed position world.WindowViewport
                     let bounds = (entity.GetBounds world).Box2
                     bounds.Intersects positionWorld
                 else false)
@@ -871,7 +871,7 @@ module WorldEntityModule =
                 if entity.GetIs2d world then
                     let position =
                         match pasteType with
-                        | PasteAtMouse -> (Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize rightClickPosition world.WindowViewport).V3
+                        | PasteAtMouse -> (Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed rightClickPosition world.WindowViewport).V3
                         | PasteAtLook -> world.Eye2dCenter.V3
                         | PasteAt position -> position
                     match positionSnapEir with

--- a/Nu/Nu/World/WorldGame.fs
+++ b/Nu/Nu/World/WorldGame.fs
@@ -275,6 +275,8 @@ module WorldGameModule =
             // set the game's state in the world
             let game = Game name
             World.setGameState gameState game world
+            let windowSize = World.getWindowSizeOtherwiseViewportSize world
+            World.synchronizeViewports windowSize world.WindowViewport.DisplayScalar world
 
             // read the game's screens
             World.readScreens gameDescriptor.ScreenDescriptors world |> ignore<Screen list>

--- a/Nu/Nu/World/WorldImGui.fs
+++ b/Nu/Nu/World/WorldImGui.fs
@@ -36,7 +36,7 @@ module WorldImGui =
             let radiusInner = ImGui.Size2dToInner (world.WindowViewport, v2Dup radius)
             for position in positions do
                 let color = computeColor position
-                let positionInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dSize, world.WindowViewport, position)
+                let positionInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dViewed, world.WindowViewport, position)
                 if filled
                 then drawList.AddEllipseFilled (positionInner, radiusInner, color.Abgr)
                 else drawList.AddEllipse (positionInner, radiusInner, color.Abgr)
@@ -54,8 +54,8 @@ module WorldImGui =
             let drawList = ImGui.GetBackgroundDrawList ()
             for struct (start, stop) in segments do
                 let color = computeColor struct (start, stop)
-                let startInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dSize, world.WindowViewport, start)
-                let stopInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dSize, world.WindowViewport, stop)
+                let startInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dViewed, world.WindowViewport, start)
+                let stopInner = ImGui.Position2dToInner (absolute, world.Eye2dCenter, world.Eye2dViewed, world.WindowViewport, stop)
                 drawList.AddLine (startInner, stopInner, color.Abgr, thickness)
 
         /// Render segments via ImGui in the current eye 2d space.

--- a/Nu/Nu/World/WorldInput.fs
+++ b/Nu/Nu/World/WorldInput.fs
@@ -38,13 +38,13 @@ module WorldInputModule =
         static member getMousePosition2dInset (world : World) =
             let viewport = world.WindowViewport
             let mousePosition = World.getMousePosition world
-            Viewport.mouseTo2dInner world.Eye2dCenter world.Eye2dSize mousePosition viewport
+            Viewport.mouseTo2dInner world.Eye2dCenter world.Eye2dViewed mousePosition viewport
 
         /// Get the 2d world position of the mouse.
         static member getMousePosition2dWorld absolute (world : World) =
             let viewport = world.WindowViewport
             let mousePosition = World.getMousePosition world
-            Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dSize mousePosition viewport
+            Viewport.mouseToWorld2d absolute world.Eye2dCenter world.Eye2dViewed mousePosition viewport
 
         /// Get the 3d screen position of the mouse.
         static member getMousePosition3dScreen (world : World) =

--- a/Nu/Nu/World/WorldModule.fs
+++ b/Nu/Nu/World/WorldModule.fs
@@ -480,6 +480,10 @@ module WorldModule =
         static member tryGetWindowFullScreen (world : World) =
             AmbientState.tryGetWindowFullScreen world.AmbientState
 
+        /// Attempt to get the pixel size of the desktop occupied by the window.
+        static member internal tryGetDisplaySize (world : World) =
+            AmbientState.tryGetDisplaySize world.AmbientState
+
         /// Attempt to set the window's full screen state.
         static member trySetWindowFullScreen fullScreen world =
             World.mapAmbientState (AmbientState.trySetWindowFullScreen fullScreen) world
@@ -531,6 +535,45 @@ module WorldModule =
         static member setWindowViewport viewport (world : World) =
             let worldExtension = { world.WorldExtension with WindowViewport = viewport }
             world.WorldState <- { world.WorldState with WorldExtension = worldExtension }
+
+        /// Synchronize all viewport-derived state from the physical window size.
+        static member private synchronizeViewportStatePositive (windowSize : Vector2i) displayScalar (world : World) =
+            let displayScalar = max 1 displayScalar
+            Globals.Render.DisplayScalar <- displayScalar
+            let gameState = world.WorldState.GameState
+            let eyeMarginMaxScalar = Vector2.Max (v2Zero, Constants.Engine.EyeMarginMaxScalar)
+            let eyeViewable = gameState.Eye2dSize * (v2Dup 1.0f + 2.0f * eyeMarginMaxScalar)
+            let eyeViewed =
+                v2
+                    (max gameState.Eye2dSize.X (min eyeViewable.X (single windowSize.X / single displayScalar)))
+                    (max gameState.Eye2dSize.Y (min eyeViewable.Y (single windowSize.Y / single displayScalar)))
+            let windowViewport = Viewport.makeWindowViewed eyeViewed windowSize
+            let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
+            let viewportInterior = Viewport.makeInteriorViewed geometryViewport.Bounds.Size
+            let viewportExterior = Viewport.makeExteriorViewed geometryViewport.Bounds.Size
+            let viewportImposter = Viewport.makeImposterViewed geometryViewport.Bounds.Size
+            let gameState =
+                { gameState with
+                    Eye2dViewed = eyeViewed
+                    Eye3dFrustumInterior =
+                        Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportInterior
+                    Eye3dFrustumExterior =
+                        Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportExterior
+                    Eye3dFrustumImposter =
+                        Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportImposter }
+            let worldExtension =
+                { world.WorldExtension with
+                    GeometryViewport = geometryViewport
+                    WindowViewport = windowViewport }
+            world.WorldState <-
+                { world.WorldState with
+                    GameState = gameState
+                    WorldExtension = worldExtension }
+
+        /// Synchronize all viewport-derived state when the window has a drawable extent.
+        static member internal synchronizeViewportState (windowSize : Vector2i) displayScalar (world : World) =
+            if windowSize.X > 0 && windowSize.Y > 0 then
+                World.synchronizeViewportStatePositive windowSize displayScalar world
 
         static member internal getSymbolics (world : World) =
             AmbientState.getSymbolics world.WorldState.AmbientState
@@ -947,7 +990,7 @@ module WorldModule =
             | (false, _)-> None
 
         static member internal makePhysicsEngine2dRenderContext segments circles (world : World) =
-            world.WorldExtension.Plugin.MakePhysicsEngine2dRenderContext segments circles world.Eye2dBounds
+            world.WorldExtension.Plugin.MakePhysicsEngine2dRenderContext segments circles world.Eye2dBoundsViewable
 
         static member internal preProcess (world : World) =
             world.WorldExtension.Plugin.PreProcess world

--- a/Nu/Nu/World/WorldModule2.fs
+++ b/Nu/Nu/World/WorldModule2.fs
@@ -454,7 +454,7 @@ module WorldModule2 =
             World.createEntity<StaticSpriteDispatcher> None DefaultOverlay (Some slideSprite.Surnames) slideGroup world |> ignore<Entity>
             World.setEntityProtection ManualProtection slideSprite world |> ignore<bool>
             slideSprite.SetPersistent false world
-            slideSprite.SetSize world.Eye2dSize.V3 world
+            slideSprite.SetSize world.Eye2dViewable.V3 world
             slideSprite.SetAbsolute true world
             match slideDescriptor.SlideImageOpt with
             | Some slideImage ->
@@ -850,11 +850,43 @@ module WorldModule2 =
             for entity in entities do
                 World.unregisterEntityPhysics entity world
 
-        static member private synchronizeViewports world =
-            let windowSize = World.getWindowSizeOtherwiseViewportSize world
-            let windowViewport = Viewport.makeWindow1 windowSize
-            World.setWindowViewport windowViewport world
-            World.setGeometryViewport (Viewport.makeGeometry windowViewport.Bounds.Size) world
+        /// Get the display's virtual resolution used for rendering and viewport sizing.
+        static member getDisplayVirtualResolution () =
+            Globals.Render.DisplayVirtualResolution
+
+        /// Set the display's virtual resolution and synchronously resynchronize window state and viewports.
+        static member setDisplayVirtualResolution (resolution : Vector2i) (world : World) =
+            if resolution.X <= 0 || resolution.Y <= 0 then
+                invalidArg (nameof resolution) "Display virtual resolution dimensions must be positive."
+            match World.tryGetDisplaySize world with
+            | Some displaySize when resolution.X > displaySize.X || resolution.Y > displaySize.Y ->
+                invalidArg
+                    (nameof resolution)
+                    ("Display virtual resolution must fit within the current desktop resolution of " +
+                     string displaySize.X + "x" + string displaySize.Y + ".")
+            | _ -> ()
+            let resolutionPrevious = Globals.Render.DisplayVirtualResolution
+            let displayScalarPrevious = Globals.Render.DisplayScalar
+            let worldStatePrevious = world.WorldState
+            let windowSizePrevious = World.tryGetWindowSize world
+            let windowFullScreenPrevious = World.tryGetWindowFullScreen world
+            try
+                Globals.Render.DisplayVirtualResolution <- resolution
+                World.processWindowResize world
+            with exn ->
+                Globals.Render.DisplayVirtualResolution <- resolutionPrevious
+                Globals.Render.DisplayScalar <- displayScalarPrevious
+                world.WorldState <- worldStatePrevious
+                try
+                    match windowFullScreenPrevious with
+                    | Some fullScreen -> World.trySetWindowFullScreen fullScreen world |> ignore
+                    | None -> ()
+                    if windowFullScreenPrevious <> Some true then
+                        match windowSizePrevious with
+                        | Some windowSize -> World.trySetWindowSize windowSize world |> ignore
+                        | None -> ()
+                with _ -> ()
+                reraise ()
 
         /// Try to reload the overlayer currently in use by the world.
         static member tryReloadOverlayer inputDirectory outputDirectory world =
@@ -949,7 +981,8 @@ module WorldModule2 =
             World.switchAmbientState world
 
             // synchronize viewports in case they get out of sync, such as during an undo operation
-            World.synchronizeViewports world
+            let windowSize = World.getWindowSizeOtherwiseViewportSize world
+            World.synchronizeViewports windowSize world.WindowViewport.DisplayScalar world
 
             // rebuild spatial trees
             Octree.clear world.Octree
@@ -1074,43 +1107,81 @@ module WorldModule2 =
                 elif keyboardKey >= KeyboardKey.F1 && keyboardKey <= KeyboardKey.F12 then ImGuiKey.F1 + (keyboardKey - KeyboardKey.F1 |> LanguagePrimitives.EnumToValue |> LanguagePrimitives.EnumOfValue) |> List.singleton
                 else []
 
-        static member internal processWindowResize (world : World) =
+        static member private processWindowResizePositive (windowSize : Vector2i) (world : World) =
 
-            // ensure window size is a factor of display virtual resolution, going to full screen otherwise
+            // validate and normalize display configuration
+            let virtualSize = Globals.Render.DisplayVirtualResolution
+            if virtualSize.X <= 0 || virtualSize.Y <= 0 then
+                invalidArg (nameof Globals.Render.DisplayVirtualResolution) "Display virtual resolution must be positive."
+            let eyeMarginMaxScalar = Vector2.Max (v2Zero, Constants.Engine.EyeMarginMaxScalar)
+            let virtualSizeWithMargin =
+                virtualSize.V2 * (v2Dup 1.0f + 2.0f * eyeMarginMaxScalar)
+            let oldDisplayScalar = max 1 world.WindowViewport.DisplayScalar
+            let minSize scalar = virtualSize * scalar
+            let maxSize scalar =
+                v2i
+                    (int (ceil (virtualSizeWithMargin.X * single scalar)))
+                    (int (ceil (virtualSizeWithMargin.Y * single scalar)))
+            let clampSize (minimum : Vector2i) (maximum : Vector2i) (size : Vector2i) =
+                v2i
+                    (max minimum.X (min maximum.X size.X))
+                    (max minimum.Y (min maximum.Y size.Y))
+            let selectDisplayScalarAndSize (windowSize : Vector2i) =
+                let oldMinimum = minSize oldDisplayScalar
+                let oldMaximum = maxSize oldDisplayScalar
+                let below = windowSize.X < oldMinimum.X || windowSize.Y < oldMinimum.Y
+                let above = windowSize.X > oldMaximum.X || windowSize.Y > oldMaximum.Y
+                let maximumRatio =
+                    max
+                        (int (ceil (single windowSize.X / single virtualSize.X)))
+                        (int (ceil (single windowSize.Y / single virtualSize.Y)))
+                let maximumScalar = max (oldDisplayScalar + 1) (maximumRatio + 1)
+                let minimumCandidate, maximumCandidate =
+                    if above && not below then oldDisplayScalar + 1, maximumScalar
+                    elif below && not above then 1, oldDisplayScalar
+                    else 1, maximumScalar
+                seq {
+                    for scalar in minimumCandidate .. maximumCandidate do
+                        let candidateSize = clampSize (minSize scalar) (maxSize scalar) windowSize
+                        let dx = int64 candidateSize.X - int64 windowSize.X
+                        let dy = int64 candidateSize.Y - int64 windowSize.Y
+                        let distanceSquared = dx * dx + dy * dy
+                        yield struct (distanceSquared, abs (scalar - oldDisplayScalar), scalar, candidateSize) }
+                |> Seq.min
+                |> fun struct (_, _, scalar, size) -> scalar, size
+            let _, snappedSize = selectDisplayScalarAndSize windowSize
+            if snappedSize <> windowSize then
+                World.trySetWindowSize snappedSize world
+                let actualWindowSize = World.getWindowSizeOtherwiseViewportSize world
+                if actualWindowSize.X < snappedSize.X || actualWindowSize.Y < snappedSize.Y then
+                    World.trySetWindowFullScreen true world
             let windowSize = World.getWindowSizeOtherwiseViewportSize world
-            let windowScalar =
-                max (single windowSize.X / single Constants.Render.DisplayVirtualResolution.X |> ceil |> int |> max 1)
-                    (single windowSize.Y / single Constants.Render.DisplayVirtualResolution.Y |> ceil |> int |> max 1)
-            let windowSize' = windowScalar * Constants.Render.DisplayVirtualResolution
-            World.trySetWindowSize windowSize' world
-            let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
-            if windowSize''.X < windowSize'.X || windowSize''.Y < windowSize'.Y then
-                World.trySetWindowFullScreen true world
+            let displayScalar, _ = selectDisplayScalarAndSize windowSize
+            World.synchronizeViewports windowSize displayScalar world
 
-            // synchronize display virtual scalar
-            let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
-            let xScalar = windowSize''.X / Constants.Render.DisplayVirtualResolution.X
-            let yScalar = windowSize''.Y / Constants.Render.DisplayVirtualResolution.Y
-            Globals.Render.DisplayScalar <- min xScalar yScalar
-
-            // synchronize view ports
-            World.synchronizeViewports world
+        static member internal processWindowResize (world : World) =
+            let windowSize = World.getWindowSizeOtherwiseViewportSize world
+            if windowSize.X > 0 && windowSize.Y > 0 then
+                World.processWindowResizePositive windowSize world
 
         static member internal processInput2 (evt : SDL_Event) (world : World) =
             match evt.Type with
             | SDL_EventType.SDL_EVENT_QUIT ->
                 let eventTrace = EventTrace.debug "World" "processInput2" "ExitRequest" EventTrace.empty
                 World.publishPlus () Nu.Game.Handle.ExitRequestEvent eventTrace Nu.Game.Handle true true world
-            | SDL_EventType.SDL_EVENT_WINDOW_RESIZED | SDL_EventType.SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED ->
+            | SDL_EventType.SDL_EVENT_WINDOW_RESIZED
+            | SDL_EventType.SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED
+            | SDL_EventType.SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED
+            | SDL_EventType.SDL_EVENT_WINDOW_ENTER_FULLSCREEN
+            | SDL_EventType.SDL_EVENT_WINDOW_LEAVE_FULLSCREEN ->
                 World.processWindowResize world
             | SDL_EventType.SDL_EVENT_MOUSE_MOTION ->
                 let io = ImGui.GetIO ()
                 let pixelDensity = World.tryGetWindowPixelDensity world |> Option.defaultValue 1.0f
-                let viewport = World.getWindowViewport world
-                io.AddMousePosEvent // scale by pixel density because SDL IO comes in from unscale window coords and offset by bounds min
-                    (evt.button.x * pixelDensity + single viewport.Bounds.Min.X,
-                     evt.button.y * pixelDensity - single viewport.Bounds.Min.Y)
-                let mousePosition = v2 (single evt.button.x) (single evt.button.y)
+                let mousePosition =
+                    v2 evt.motion.x evt.motion.y * pixelDensity -
+                    world.WindowViewport.Bounds.Min.V2
+                io.AddMousePosEvent (mousePosition.X, mousePosition.Y)
                 if World.isMouseButtonDown MouseLeft world then
                     let eventTrace = EventTrace.debug "World" "processInput2" "MouseDrag" EventTrace.empty
                     World.publishPlus { MouseMoveData.Position = mousePosition } Nu.Game.Handle.MouseDragEvent eventTrace Nu.Game.Handle true true world
@@ -1539,8 +1610,8 @@ module WorldModule2 =
 
         static member private renderScreenTransition renderPass (screen : Screen) world =
             match screen.GetTransitionState world with
-            | IncomingState transitionTime -> World.renderScreenTransition5 transitionTime world.Eye2dSize renderPass (screen.GetIncoming world) world
-            | OutgoingState transitionTime -> World.renderScreenTransition5 transitionTime world.Eye2dSize renderPass (screen.GetOutgoing world) world
+            | IncomingState transitionTime -> World.renderScreenTransition5 transitionTime world.Eye2dViewed renderPass (screen.GetIncoming world) world
+            | OutgoingState transitionTime -> World.renderScreenTransition5 transitionTime world.Eye2dViewed renderPass (screen.GetOutgoing world) world
             | IdlingState _ -> ()
 
         static member private renderSimulantsInternal8
@@ -2075,7 +2146,7 @@ module WorldModule2 =
                                                                         world.Eye3dRotation
                                                                         world.Eye3dFieldOfView
                                                                         world.Eye2dCenter
-                                                                        world.Eye2dSize
+                                                                        world.Eye2dViewed
                                                                         world.GeometryViewport
                                                                         world.WindowViewport
                                                                         windowProperties

--- a/Nu/Nu/World/WorldModuleGame.fs
+++ b/Nu/Nu/World/WorldModuleGame.fs
@@ -38,6 +38,13 @@ module WorldModuleGame =
             ignore<Game> game
             world.WorldState <- { world.WorldState with GameState = gameState }
 
+        static member internal synchronizeViewports windowSize displayScalar (world : World) =
+            let eyeViewedPrevious = world.GameState.Eye2dViewed
+            World.synchronizeViewportState windowSize displayScalar world
+            let eyeViewed = world.GameState.Eye2dViewed
+            if eyeViewedPrevious <> eyeViewed then
+                World.publishGameChange (nameof world.GameState.Eye2dViewed) eyeViewedPrevious eyeViewed Game.Handle world
+
         static member internal getGameXtension game world =
             let gameState = World.getGameState game world
             gameState.Xtension
@@ -208,6 +215,8 @@ module WorldModuleGame =
             let previous = gameState.Eye2dSize
             if previous <> value then
                 World.setGameState { gameState with Eye2dSize = value } game world
+                let windowSize = World.getWindowSizeOtherwiseViewportSize world
+                World.synchronizeViewports windowSize world.WindowViewport.DisplayScalar world
                 World.publishGameChange (nameof gameState.Eye2dSize) previous value game world
                 true
             else false
@@ -220,6 +229,13 @@ module WorldModuleGame =
         static member setEye2dSize value world =
             World.setGameEye2dSize value Game.Handle world |> ignore<bool>
 
+        static member internal getGameEye2dViewed game world =
+            (World.getGameState game world).Eye2dViewed
+
+        /// Get the current 2d eye viewed size.
+        static member getEye2dViewed world =
+            World.getGameEye2dViewed Game.Handle world
+
         /// Get the current 2d eye bounds.
         static member getEye2dBounds world =
             let eyeCenter = World.getGameEye2dCenter Game.Handle world
@@ -227,8 +243,8 @@ module WorldModuleGame =
             box2 (eyeCenter - eyeSize * 0.5f) eyeSize
 
         /// Constrain the eye to the given 2d bounds.
-        static member constrainEye2dBounds (bounds : Box2) world =
-            let mutable eyeBounds = World.getEye2dBounds world
+        static member constrainEye2dBounds (bounds : Box2) (world : World) =
+            let mutable eyeBounds = world.Eye2dBoundsViewed
             eyeBounds.Min <-
                 v2
                     (if eyeBounds.Min.X < bounds.Min.X then bounds.Min.X
@@ -243,23 +259,25 @@ module WorldModuleGame =
         /// Get the bounds of the 2d eye's sight irrespective of its position.
         static member getViewBounds2dAbsolute world =
             let gameState = World.getGameState Game.Handle world
-            box2
-                (v2 (gameState.Eye2dSize.X * -0.5f) (gameState.Eye2dSize.Y * -0.5f))
-                (v2 gameState.Eye2dSize.X gameState.Eye2dSize.Y)
+            box2 (gameState.Eye2dViewed * -0.5f) gameState.Eye2dViewed
 
         /// Get the bounds of the 2d eye's sight relative to its position.
         static member getViewBounds2dRelative world =
             let gameState = World.getGameState Game.Handle world
-            let min = v2 (gameState.Eye2dCenter.X - gameState.Eye2dSize.X * 0.5f) (gameState.Eye2dCenter.Y - gameState.Eye2dSize.Y * 0.5f)
-            box2 min gameState.Eye2dSize
+            let eyeViewed = gameState.Eye2dViewed
+            box2 (gameState.Eye2dCenter - eyeViewed * 0.5f) eyeViewed
 
         /// Get the bounds of the 2d play zone irrespective of eye center.
         static member getPlayBounds2dAbsolute world =
-            World.getViewBounds2dAbsolute world
+            let gameState = World.getGameState Game.Handle world
+            let eyeViewable = gameState.Eye2dSize + gameState.Eye2dSize * 2.0f * Constants.Engine.EyeMarginMaxScalar
+            box2 (eyeViewable * -0.5f) eyeViewable
 
         /// Get the bounds of the 2d play zone relative to eye center.
         static member getPlayBounds2dRelative world =
-            World.getViewBounds2dRelative world
+            let gameState = World.getGameState Game.Handle world
+            let eyeViewable = gameState.Eye2dSize + gameState.Eye2dSize * 2.0f * Constants.Engine.EyeMarginMaxScalar
+            box2 (gameState.Eye2dCenter - eyeViewable * 0.5f) eyeViewable
 
         /// Check that the given bounds is within the 2d eye's sight irrespective of eye center.
         static member boundsInView2dAbsolute (bounds : Box2) world =
@@ -288,9 +306,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dCenter
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = world.GeometryViewport.Bounds.Size
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dCenter = value
@@ -317,9 +336,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dRotation
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = world.GeometryViewport.Bounds.Size
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dRotation = value
@@ -347,9 +367,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dFieldOfView
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = world.GeometryViewport.Bounds.Size
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dFieldOfView = value
@@ -361,11 +382,9 @@ module WorldModuleGame =
                 true
             else false
 
-        static member internal getGameEye3dAspectRatio game world =
+        static member internal getGameEye3dAspectRatio game (world : World) =
             ignore<Game> game
-            ignore<World> world
-            single Constants.Render.DisplayVirtualResolution.X /
-            single Constants.Render.DisplayVirtualResolution.Y
+            world.GeometryViewport.AspectRatio
 
         /// Get the current 3d eye field of view.
         static member getEye3dFieldOfView world =

--- a/Nu/Nu/World/WorldPrelude.fs
+++ b/Nu/Nu/World/WorldPrelude.fs
@@ -679,6 +679,11 @@ module internal AmbientState =
             Some fullScreen
         | _ -> None
 
+    let internal tryGetDisplaySize state =
+        state.SdlDepsOpt
+        |> Option.bind SdlDeps.tryGetDisplayMode
+        |> Option.map (fun displayMode -> v2i displayMode.w displayMode.h)
+
     let internal trySetWindowFullScreen fullScreen state =
         match state.SdlDepsOpt with
         | Some deps -> { state with SdlDepsOpt = Some (SdlDeps.trySetWindowFullScreen fullScreen deps) }

--- a/Nu/Nu/World/WorldTypes.fs
+++ b/Nu/Nu/World/WorldTypes.fs
@@ -1007,6 +1007,7 @@ and [<ReferenceEquality; CLIMutable>] GameState =
       ScreenTransitionDestinationOpt : Screen option
       Eye2dCenter : Vector2
       Eye2dSize : Vector2
+      Eye2dViewed : Vector2
       Eye3dCenter : Vector3
       Eye3dRotation : Quaternion
       Eye3dFieldOfView : single
@@ -1059,7 +1060,8 @@ and [<ReferenceEquality; CLIMutable>] GameState =
           SelectedScreenOpt = None
           ScreenTransitionDestinationOpt = None
           Eye2dCenter = v2Zero
-          Eye2dSize = Constants.Render.DisplayVirtualResolution.V2
+          Eye2dSize = Globals.Render.DisplayVirtualResolution.V2
+          Eye2dViewed = Globals.Render.DisplayVirtualResolution.V2
           Eye3dCenter = eye3dCenter
           Eye3dRotation = eye3dRotation
           Eye3dFieldOfView = eye3dFieldOfView
@@ -2199,15 +2201,42 @@ and [<NoEquality; NoComparison>] World =
     member this.Eye2dCenter =
         this.GameState.Eye2dCenter
 
-    /// Get the size of the 2D eye.
+    /// Get the size of the 2D eye, viewable for all window dimensions.
     member this.Eye2dSize =
         this.GameState.Eye2dSize
 
-    /// Get the bounds of the 2D eye.
+    /// Get the viewed size of the 2D eye, for the current window.
+    member this.Eye2dViewed =
+        this.GameState.Eye2dViewed
+
+    /// Get the viewable size of the 2D eye, for any potential window dimension.
+    member this.Eye2dViewable =
+        let eyeSize = this.Eye2dSize
+        eyeSize + eyeSize * 2.0f * Constants.Engine.EyeMarginMaxScalar
+
+    /// Get the bounds of the 2D eye, viewable for all window dimensions.
     member this.Eye2dBounds =
         let eyeCenter = this.Eye2dCenter
         let eyeSize = this.Eye2dSize
         box2 (eyeCenter - eyeSize * 0.5f) eyeSize
+
+    /// Get the viewed bounds of the 2D eye, for the current window.
+    member this.Eye2dBoundsViewed =
+        let eyeCenter = this.Eye2dCenter
+        let eyeViewed = this.GameState.Eye2dViewed
+        box2 (eyeCenter - eyeViewed * 0.5f) eyeViewed
+
+    /// Get the viewable bounds of the 2D eye, for any potential window dimension.
+    member this.Eye2dBoundsViewable =
+        let eyeCenter = this.Eye2dCenter
+        let eyeViewable = this.Eye2dViewable
+        box2 (eyeCenter - eyeViewable * 0.5f) eyeViewable
+
+    /// Get the margin of the 2D eye, viewed beyond Eye2dSize on each side, for the current window.
+    /// Add or subtract X to anchor an entity to the right or left edge of the window.
+    /// Add or subtract Y to anchor an entity to the top or bottom edge of the window.
+    member this.Eye2dMargin =
+        (this.Eye2dViewed - this.Eye2dSize) * 0.5f
 
     /// Get the center of the 3D eye.
     member this.Eye3dCenter =

--- a/Projects/Mobile/App.config
+++ b/Projects/Mobile/App.config
@@ -2,5 +2,6 @@
 <configuration>
   <appSettings>
     <add key="DisplayScalar" value="2" />
+    <add key="EyeMarginMaxScalar" value="[0.25 0.2]" />
   </appSettings>
 </configuration>

--- a/Projects/Mobile/Program.fs
+++ b/Projects/Mobile/Program.fs
@@ -11,6 +11,8 @@ let main firstFrameCallback =
 
     // NOTE: keep Orientations in sync with the ones specified for ScreenOrientation below and in "App/iOS Info.plist" file.
     // the platform-specific orientations are applied to the splash screen before SDL sets orientations, so they must match to avoid a brief orientation change when the splash screen is removed.
+    // HINT: Change EyeMarginMaxScalar in App.config to allow the window area to accommodate for different mobile screen sizes.
+    // The 2d eye can extend up to (EyeMarginMaxScalar * Eye2dSize) on each side, so that the world can be rendered up to the edges of the window without being clipped.
     let sdlOrientations = Set.ofList [LandscapeLeft; LandscapeRight]
 
     // this specifies the window configuration used to display the game

--- a/Projects/Sand Box 2d/App.config
+++ b/Projects/Sand Box 2d/App.config
@@ -2,5 +2,6 @@
 <configuration>
   <appSettings>
     <add key="DisplayScalar" value="2" />
+    <add key="EyeMarginMaxScalar" value="[0.15 0.15]" />
   </appSettings>
 </configuration>

--- a/Projects/Sand Box 2d/FluidSim.fs
+++ b/Projects/Sand Box 2d/FluidSim.fs
@@ -161,13 +161,13 @@ type FluidSimDispatcher () =
 
             // particle count button
             World.doText $"Particle Count"
-                [Entity.Position .= v3 255f 170f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) 170f 0f
                  Entity.Text @= $"{(fluidEmitter.GetFluidParticles world).Length} Particles"
                  Entity.Elevation .= 1f] world
 
             // clear button
             if World.doButton $"Clear"
-                [Entity.Position .= v3 255f 140f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) 140f 0f
                  Entity.Text .= "Clear"
                  Entity.Elevation .= 1f] world then
                 World.clearFluidParticles fluidEmitterId world
@@ -185,7 +185,7 @@ type FluidSimDispatcher () =
             for i in 0 .. dec gravities.Length do
                 if World.getGravity2d world = snd gravities[i] then
                     if World.doButton $"Gravity"
-                        [Entity.Position .= v3 255f 110f 0f
+                        [Entity.Position @= v3 (255f + world.Eye2dMargin.X) 110f 0f
                          Entity.Text @= $"Gravity: {fst gravities[i]}"
                          Entity.Elevation .= 1f] world then
                         World.setGravity2d (snd gravities[(i + 1) % gravities.Length]) world
@@ -194,7 +194,7 @@ type FluidSimDispatcher () =
             let particleRenders = fluidEmitter.GetFluidParticleRenders world
             let particleImage = particleRenders["Water"].Image
             if World.doButton $"Particle Sprite"
-                [Entity.Position .= v3 255f 80f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) 80f 0f
                  Entity.Text @= $"Particle Sprite: {particleImage.AssetName}"
                  Entity.Elevation .= 1f
                  Entity.FontSizing .= Some 8.f] world then
@@ -230,7 +230,7 @@ type FluidSimDispatcher () =
 
             // tool palette panel
             World.beginPanel "Tool Panel"
-                [Entity.Position .= v3 255f -10f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -10f 0f
                  Entity.Size .= v3 128f 153f 0f
                  Entity.Elevation .= 1f] world |> ignore
 
@@ -277,7 +277,7 @@ type FluidSimDispatcher () =
 
             // squish button
             if World.doButton $"Squish"
-                [Entity.Position .= v3 255f -100f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -100f 0f
                  Entity.Text .= "Squish"
                  Entity.Elevation .= 1f] world then
                 let paddle = World.createEntity<BlockBody2dDispatcher> None DefaultOverlay None world.ContextGroup world
@@ -292,13 +292,13 @@ type FluidSimDispatcher () =
 
             // switch screen button
             World.doButton Simulants.ToyBoxSwitchScreen.Name
-                [Entity.Position .= v3 255f -130f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -130f 0f
                  Entity.Text .= "Switch Screen"
                  Entity.Elevation .= 1f] world |> ignore
 
             // info button
             if World.doButton "Info"
-                [Entity.Position .= v3 255f -160f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -160f 0f
                  Entity.Text .= "Info"
                  Entity.Elevation .= 1f] world then
                 fluidSim.SetInfoOpened true world
@@ -308,14 +308,14 @@ type FluidSimDispatcher () =
 
                 // declare info background - block button interactions behind info panel while opened
                 World.doPanel "Info Background"
-                    [Entity.Size .= Constants.Render.DisplayVirtualResolution.V3
+                    [Entity.Size .= world.Eye2dViewable.V3
                      Entity.Elevation .= 10f
                      Entity.BackdropImageOpt .= Some Assets.Default.Black
                      Entity.Color .= color 0f 0f 0f 0.5f] world
 
                 // being info panel declaration
                 World.beginPanel "Info Panel"
-                    [Entity.Size .= Constants.Render.DisplayVirtualResolution.V3 * 0.8f
+                    [Entity.Size .= Globals.Render.DisplayVirtualResolution.V3 * 0.8f
                      Entity.Layout .= Grid (v2i 1 5, Some FlowDownward, true)
                      Entity.Elevation .= 10f] world
 

--- a/Projects/Sand Box 2d/RaceCourse.fs
+++ b/Projects/Sand Box 2d/RaceCourse.fs
@@ -77,7 +77,7 @@ type RaceCourseDispatcher () =
 
             // declare border
             World.doStaticSprite Simulants.RaceCourseBorder.Name
-                [Entity.Size .= v3 640f 360f 0f
+                [Entity.Size .= world.Eye2dViewable.V3
                  Entity.Elevation .= -1f
                  Entity.Absolute .= true // displays at the same screen location regardless of the eye position
                  Entity.StaticImage .= Assets.Gameplay.BackgroundImage] world

--- a/Projects/Sand Box 2d/ToyBox.fs
+++ b/Projects/Sand Box 2d/ToyBox.fs
@@ -910,6 +910,16 @@ type ToyBoxDispatcher () =
             // all entities must be in a group - groups are the unit of entity loading
             World.beginGroup Simulants.ToyBoxScene.Name [] world
 
+            World.doStaticSprite "Background"
+                // With EyeMarginMaxScalar in App.config, we allow the window size to extend beyond DisplayVirtualResolution
+                // by a margin up to the specified multiple of DisplayVirtualResolution. This can accommodate for
+                // closely matching screen sizes especially on mobile devices. The eye 2d viewable size ensures this image
+                // fills for all window sizes, even if smaller window sizes only see a crop of this image.
+                [Entity.Size .= world.Eye2dViewable.V3
+                 Entity.Absolute .= true
+                 Entity.StaticImage .= Assets.Default.AnimatedSprite
+                 Entity.Elevation .= -2f] world |> ignore
+
             // declare border
             World.doBlockBody2d Simulants.ToyBoxBorder.Name // uses static physics by default - it does not react to forces or collisions
                 [Entity.Size .= v3 500f 350f 0f
@@ -975,14 +985,16 @@ type ToyBoxDispatcher () =
                 // first page of add toy buttons
                 for (i, entityType) in List.indexed [Box; Ball; TinyBalls; Spring; Block; Bridge; Fan] do
                     if World.doButton $"Add {scstringMemo entityType}"
-                        [Entity.Position .= v3 255f (160f - 30f * single i) 0f
+                        // With EyeMarginMaxScalar in App.config, we also need to ensure
+                        // right alignment on any window size by adding the margin width.
+                        [Entity.Position @= v3 (255f + world.Eye2dMargin.X) (160f - 30f * single i) 0f
                          Entity.Text .= $"Add {scstringMemo entityType}"
                          Entity.Elevation .= 1f] world then
                         toyBox.Toys.Map (FMap.add Gen.name entityType) world
                 
                 // next page
                 if World.doButton "Down"
-                    [Entity.Position .= v3 255f -50f 0f
+                    [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -50f 0f
                      Entity.Text .= "v"
                      Entity.Elevation .= 1f] world then
                     toyBox.SetMenuPage MenuPage2 world
@@ -991,7 +1003,7 @@ type ToyBoxDispatcher () =
 
                 // previous page
                 if World.doButton "Up"
-                    [Entity.Position .= v3 255f 160f 0f
+                    [Entity.Position @= v3 (255f + world.Eye2dMargin.X) 160f 0f
                      Entity.Text .= "^"
                      Entity.Elevation .= 1f] world then
                     toyBox.SetMenuPage MenuPage1 world
@@ -999,7 +1011,7 @@ type ToyBoxDispatcher () =
                 // second page of add toy buttons
                 for (i, entityType) in List.indexed [Clamp; Ragdoll; SoftBody; Web; Strandbeest] do
                     if World.doButton $"Add {scstringMemo entityType}"
-                        [Entity.Position .= v3 255f (130f - 30f * single i) 0f
+                        [Entity.Position @= v3 (255f + world.Eye2dMargin.X) (130f - 30f * single i) 0f
                          Entity.Text .= $"Add {scstringMemo entityType}"
                          Entity.Elevation .= 1f] world then
                         toyBox.Toys.Map (FMap.add Gen.name entityType) world
@@ -1009,7 +1021,7 @@ type ToyBoxDispatcher () =
                 let gravity = List.head (toyBox.GetGravities world)
                 World.setGravity2d (snd gravity) world
                 if World.doButton $"Gravity"
-                    [Entity.Position .= v3 255f -20f 0f
+                    [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -20f 0f
                      Entity.Text @= $"Gravity: {fst gravity}"
                      Entity.Elevation .= 1f] world then
                     toyBox.Gravities.Map List.tail world
@@ -1019,7 +1031,7 @@ type ToyBoxDispatcher () =
                 let gravity = List.head (toyBox.GetAvatarGravities world)
                 avatar.SetGravity (snd gravity) world
                 if World.doButton $"Avatar Gravity"
-                    [Entity.Position .= v3 255f -50f 0f
+                    [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -50f 0f
                      Entity.Text @= $"Avatar Gravity: {fst gravity}"
                      Entity.Elevation .= 1f
                      Entity.FontSizing .= Some 10.f] world then
@@ -1027,7 +1039,7 @@ type ToyBoxDispatcher () =
 
             // clear toys button
             if World.doButton "Clear Toys"
-                [Entity.Position .= v3 255f -100f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -100f 0f
                  Entity.Text .= "Clear Toys"
                  Entity.Elevation .= 1f] world then
                 toyBox.SetToys FMap.empty world
@@ -1036,13 +1048,13 @@ type ToyBoxDispatcher () =
 
             // switch screen button
             World.doButton Simulants.ToyBoxSwitchScreen.Name
-                [Entity.Position .= v3 255f -130f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -130f 0f
                  Entity.Text .= "Switch Screen"
                  Entity.Elevation .= 1f] world |> ignore
 
             // info button
             if World.doButton "Info"
-                [Entity.Position .= v3 255f -160f 0f
+                [Entity.Position @= v3 (255f + world.Eye2dMargin.X) -160f 0f
                  Entity.Text .= "Info"
                  Entity.Elevation .= 1f] world then
                 toyBox.SetInfoOpened true world
@@ -1052,14 +1064,14 @@ type ToyBoxDispatcher () =
 
                 // declare info background - block button interactions behind info panel while opened
                 World.doPanel "Info Background"
-                    [Entity.Size .= Constants.Render.DisplayVirtualResolution.V3
+                    [Entity.Size .= world.Eye2dViewable.V3
                      Entity.Elevation .= 10f
                      Entity.BackdropImageOpt .= Some Assets.Default.Black
                      Entity.Color .= color 0f 0f 0f 0.5f] world
 
                 // being info panel declaration
                 World.beginPanel "Info Panel"
-                    [Entity.Size .= Constants.Render.DisplayVirtualResolution.V3 * 0.8f
+                    [Entity.Size .= Globals.Render.DisplayVirtualResolution.V3 * 0.8f
                      // we can use a grid to nicely organize Gui elements.
                      // flow direction first orders by Entity.LayoutOrder which is
                      // defined for all Gui elements (via LayoutFacet), then it orders by Entity.Order.


### PR DESCRIPTION
Minimized re-submission of the viewport-resize split branch.

Single squashed commit on `vulkan-resolve-texture`. Tree is identical to the previously pushed `split/pr-1392-viewport-resize` on this repo except that an unrelated NuGet proxy-fallback script change (`SelectCompatibleAssetDeliveryVersion.fsx`) has been stripped.

Supersedes the same-named branch here (safe to delete).

Model: ox-alpha (opencode/big-pickle)
