### PR TITLE
Support runtime display virtual resolution

### DIFF
--- a/Nu/Nu.Tests/WorldTests.fs
+++ b/Nu/Nu.Tests/WorldTests.fs
@@ -12,6 +12,64 @@ open Nu
 open Nu.Tests
 module WorldTests =
 
+    let private makeStubWorld () =
+        Nu.init ()
+        World.makeStub (constant None) { WorldConfig.defaultConfig with Accompanied = true } (TestPlugin ())
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution synchronizes world state immediately.`` () =
+        let previousScalar = Globals.Render.DisplayScalar
+        let world = makeStubWorld ()
+        let oldWindowViewport = world.WindowViewport
+        let eyeSizePrevious = world.Eye2dSize
+        let resolution = System.Numerics.Vector2i (800, 600)
+        World.setDisplayVirtualResolution resolution world
+        Assert.Equal (resolution, World.getDisplayVirtualResolution world)
+        Assert.Equal (eyeSizePrevious, world.Eye2dSize)
+        Assert.Equal (Globals.Render.DisplayScalar, world.WindowViewport.DisplayScalar)
+        Assert.That (world.WindowViewport, Is.Not.EqualTo oldWindowViewport)
+        let geometryBounds = System.Numerics.Box2i (System.Numerics.Vector2i.Zero, world.GeometryViewport.Bounds.Size)
+        let expectedViewport =
+            Viewport.make
+                Constants.Render.NearPlaneDistanceInterior
+                Constants.Render.FarPlaneDistanceInterior
+                geometryBounds
+                geometryBounds
+                geometryBounds
+        let expectedFrustum =
+            Viewport.getFrustum world.Eye3dCenter world.Eye3dRotation world.Eye3dFieldOfView expectedViewport
+        Assert.Equal (expectedFrustum, world.Eye3dFrustumInterior)
+        Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution preserves custom eye size.`` () =
+        let previousScalar = Globals.Render.DisplayScalar
+        let world = makeStubWorld ()
+        let customEyeSize = System.Numerics.Vector2 (123.0f, 77.0f)
+        World.setEye2dSize customEyeSize world
+        World.setDisplayVirtualResolution (System.Numerics.Vector2i (800, 600)) world
+        Assert.Equal (customEyeSize, world.Eye2dSize)
+        Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Invalid display virtual resolution is rejected without changing state.`` () =
+        let previousScalar = Globals.Render.DisplayScalar
+        let world = makeStubWorld ()
+        let eyeSize = world.Eye2dSize
+        let windowViewport = world.WindowViewport
+        let geometryViewport = world.GeometryViewport
+        let resolutionPrevious = World.getDisplayVirtualResolution world
+        World.setDisplayVirtualResolution (System.Numerics.Vector2i (0, 450)) world
+        Assert.Equal (resolutionPrevious, World.getDisplayVirtualResolution world)
+        Assert.Equal (eyeSize, world.Eye2dSize)
+        Assert.Equal (windowViewport, world.WindowViewport)
+        Assert.Equal (geometryViewport, world.GeometryViewport)
+        Globals.Render.DisplayScalar <- previousScalar
+
+    let [<Test; NonParallelizable>] ``Display virtual resolution remains supported without an SDL display.`` () =
+        let previousScalar = Globals.Render.DisplayScalar
+        let world = makeStubWorld ()
+        World.setDisplayVirtualResolution (System.Numerics.Vector2i (2000, 1200)) world
+        Assert.Equal (System.Numerics.Vector2i (2000, 1200), World.getDisplayVirtualResolution world)
+        Globals.Render.DisplayScalar <- previousScalar
+
     let [<Test>] ``Run empty frame then clean up.`` () =
         Nu.init ()
         let world = World.makeStub (constant None) { WorldConfig.defaultConfig with Accompanied = true } (TestPlugin ())

--- a/Nu/Nu/Core/Constants.fs
+++ b/Nu/Nu/Core/Constants.fs
@@ -200,6 +200,8 @@ module Render =
     let [<Uniform>] mutable FarPlaneDistanceImposter = match ConfigurationManager.AppSettings["FarPlaneDistanceImposter"] with null -> 4096.0f | value -> scvalue value
     let [<Uniform>] mutable NearPlaneDistanceOmnipresent = NearPlaneDistanceInterior
     let [<Uniform>] mutable FarPlaneDistanceOmnipresent = FarPlaneDistanceImposter
+    /// The boot default of the display virtual resolution. Once a world is created, the world's own display virtual
+    /// resolution (seeded from here) is authoritative; change it at runtime through World.setDisplayVirtualResolution.
     let [<Uniform>] mutable DisplayVirtualResolution = match ConfigurationManager.AppSettings["DisplayVirtualResolution"] with null -> v2i 640 360 | value -> scvalue value
     let [<Uniform>] mutable SsaoResolutionDivisor = match ConfigurationManager.AppSettings["SsaoResolutionDivisor"] with null -> 1 | value -> scvalue value
     let [<Uniform>] Play3dBoxSize = Vector3 64.0f

--- a/Nu/Nu/Core/Globals.fs
+++ b/Nu/Nu/Core/Globals.fs
@@ -1,4 +1,4 @@
-﻿// Nu Game Engine.
+// Nu Game Engine.
 // Required Notice:
 // Copyright (C) Bryan Edds.
 // Nu Game Engine is licensed under the Nu Game Engine Noncommercial License.

--- a/Nu/Nu/Transform/Viewport.fs
+++ b/Nu/Nu/Transform/Viewport.fs
@@ -252,23 +252,35 @@ type [<StructuralEquality; NoComparison>] Viewport =
         let outer = box2i v2iZero windowSize
         Viewport.make Constants.Render.NearPlaneDistanceOmnipresent Constants.Render.FarPlaneDistanceOmnipresent inner bounds outer
 
-    static member makeWindow1 (windowSize : Vector2i) =
-        let boundsSize = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
+    static member makeWindowResolution (virtualResolution : Vector2i) (windowSize : Vector2i) =
+        let boundsSize = virtualResolution * Globals.Render.DisplayScalar
         let boundsMin = Vector2i ((windowSize.X - boundsSize.X) / 2, (windowSize.Y - boundsSize.Y) / 2)
         let bounds = box2i boundsMin boundsSize
         Viewport.makeWindow bounds bounds windowSize // presume inner = bounds
 
+    static member makeWindow1 (windowSize : Vector2i) =
+        Viewport.makeWindowResolution Constants.Render.DisplayVirtualResolution windowSize
+
+    static member makeInteriorViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
+        Viewport.make Constants.Render.NearPlaneDistanceInterior Constants.Render.FarPlaneDistanceInterior bounds bounds bounds
+
     static member makeInterior () =
         let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
-        Viewport.make Constants.Render.NearPlaneDistanceInterior Constants.Render.FarPlaneDistanceInterior bounds bounds bounds
+        Viewport.makeInteriorViewed outerResolution
+
+    static member makeExteriorViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
+        Viewport.make Constants.Render.NearPlaneDistanceExterior Constants.Render.FarPlaneDistanceExterior bounds bounds bounds
 
     static member makeExterior () =
         let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
-        Viewport.make Constants.Render.NearPlaneDistanceExterior Constants.Render.FarPlaneDistanceExterior bounds bounds bounds
+        Viewport.makeExteriorViewed outerResolution
+
+    static member makeImposterViewed (resolution : Vector2i) =
+        let bounds = box2i v2iZero resolution
+        Viewport.make Constants.Render.NearPlaneDistanceImposter Constants.Render.FarPlaneDistanceImposter bounds bounds bounds
 
     static member makeImposter () =
         let outerResolution = Constants.Render.DisplayVirtualResolution * Globals.Render.DisplayScalar
-        let bounds = box2i v2iZero outerResolution
-        Viewport.make Constants.Render.NearPlaneDistanceImposter Constants.Render.FarPlaneDistanceImposter bounds bounds bounds
+        Viewport.makeImposterViewed outerResolution

--- a/Nu/Nu/World/World.fs
+++ b/Nu/Nu/World/World.fs
@@ -458,6 +458,7 @@ module WorldModule4 =
                   JobGraph = jobGraph
                   GeometryViewport = geometryViewport
                   WindowViewport = windowViewport
+                  DisplayVirtualResolution = Constants.Render.DisplayVirtualResolution
                   DestructionListRev = []
                   LateBindingsInstances = lateBindingsInstances
                   TryMakeEditContext = tryMakeEditContext

--- a/Nu/Nu/World/WorldModule.fs
+++ b/Nu/Nu/World/WorldModule.fs
@@ -487,6 +487,14 @@ module WorldModule =
         static member tryGetWindowFullScreen (world : World) =
             AmbientState.tryGetWindowFullScreen world.AmbientState
 
+        /// Attempt to get the pixel size of the desktop occupied by the window.
+        static member internal tryGetDisplaySize (world : World) =
+            AmbientState.tryGetDisplaySize world.AmbientState
+
+        /// Get the display's virtual resolution used for rendering and viewport sizing.
+        static member getDisplayVirtualResolution (world : World) =
+            world.WorldExtension.DisplayVirtualResolution
+
         /// Attempt to set the window's full screen state.
         static member trySetWindowFullScreen fullScreen world =
             World.mapAmbientState (AmbientState.trySetWindowFullScreen fullScreen) world

--- a/Nu/Nu/World/WorldModule2.fs
+++ b/Nu/Nu/World/WorldModule2.fs
@@ -852,9 +852,38 @@ module WorldModule2 =
 
         static member private synchronizeViewports world =
             let windowSize = World.getWindowSizeOtherwiseViewportSize world
-            let windowViewport = Viewport.makeWindow1 windowSize
+            let windowViewport = Viewport.makeWindowResolution (World.getDisplayVirtualResolution world) windowSize
+
             World.setWindowViewport windowViewport world
             World.setGeometryViewport (Viewport.makeGeometry windowViewport.Bounds.Size) world
+
+            // Rebuild cached 3d frusta because their aspect ratio depends on the virtual resolution.
+            let gameState = World.getGameState Nu.Game.Handle world
+            let resolution = World.getDisplayVirtualResolution world * Globals.Render.DisplayScalar
+            let viewportInterior = Viewport.makeInteriorViewed resolution
+            let viewportExterior = Viewport.makeExteriorViewed resolution
+            let viewportImposter = Viewport.makeImposterViewed resolution
+            World.setGameState
+                { gameState with
+                    Eye3dFrustumInterior = Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportInterior
+                    Eye3dFrustumExterior = Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportExterior
+                    Eye3dFrustumImposter = Viewport.getFrustum gameState.Eye3dCenter gameState.Eye3dRotation gameState.Eye3dFieldOfView viewportImposter }
+                Nu.Game.Handle
+                world
+
+        /// Set the display's virtual resolution and synchronously resynchronize window state and viewports.
+        static member setDisplayVirtualResolution (resolution : Vector2i) (world : World) =
+            if resolution.X <= 0 || resolution.Y <= 0 then
+                Log.error ("Display virtual resolution dimensions must be positive, but were " + string resolution.X + "x" + string resolution.Y + ".")
+            else
+                match World.tryGetDisplaySize world with
+                | Some displaySize when resolution.X > displaySize.X || resolution.Y > displaySize.Y ->
+                    Log.error ("Display virtual resolution must fit within the current desktop resolution of " +
+                               string displaySize.X + "x" + string displaySize.Y + ".")
+                | _ ->
+                    let worldExtension = world.WorldExtension
+                    world.WorldState <- { world.WorldState with WorldExtension = { worldExtension with DisplayVirtualResolution = resolution } }
+                    World.processWindowResize world
 
         /// Try to reload the overlayer currently in use by the world.
         static member tryReloadOverlayer inputDirectory outputDirectory world =
@@ -1077,24 +1106,28 @@ module WorldModule2 =
         static member internal processWindowResize (world : World) =
 
             // ensure window size is a factor of display virtual resolution, going to full screen otherwise
+            let virtualResolution = World.getDisplayVirtualResolution world
             let windowSize = World.getWindowSizeOtherwiseViewportSize world
-            let windowScalar =
-                max (single windowSize.X / single Constants.Render.DisplayVirtualResolution.X |> ceil |> int |> max 1)
-                    (single windowSize.Y / single Constants.Render.DisplayVirtualResolution.Y |> ceil |> int |> max 1)
-            let windowSize' = windowScalar * Constants.Render.DisplayVirtualResolution
-            World.trySetWindowSize windowSize' world
-            let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
-            if windowSize''.X < windowSize'.X || windowSize''.Y < windowSize'.Y then
-                World.trySetWindowFullScreen true world
+            if virtualResolution.X <= 0 || virtualResolution.Y <= 0 then
+                Log.error ("Display virtual resolution must be positive, but was " + string virtualResolution.X + "x" + string virtualResolution.Y + ".")
+            else
+                let windowScalar =
+                    max (single windowSize.X / single virtualResolution.X |> ceil |> int |> max 1)
+                        (single windowSize.Y / single virtualResolution.Y |> ceil |> int |> max 1)
+                let windowSize' = windowScalar * virtualResolution
+                World.trySetWindowSize windowSize' world
+                let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
+                if windowSize''.X < windowSize'.X || windowSize''.Y < windowSize'.Y then
+                    World.trySetWindowFullScreen true world
 
-            // synchronize display virtual scalar
-            let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
-            let xScalar = windowSize''.X / Constants.Render.DisplayVirtualResolution.X
-            let yScalar = windowSize''.Y / Constants.Render.DisplayVirtualResolution.Y
-            Globals.Render.DisplayScalar <- min xScalar yScalar
+                // synchronize display virtual scalar
+                let windowSize'' = World.getWindowSizeOtherwiseViewportSize world
+                let xScalar = windowSize''.X / virtualResolution.X
+                let yScalar = windowSize''.Y / virtualResolution.Y
+                Globals.Render.DisplayScalar <- max 1 (min xScalar yScalar)
 
-            // synchronize view ports
-            World.synchronizeViewports world
+                // synchronize view ports
+                World.synchronizeViewports world
 
         static member internal processInput2 (evt : SDL_Event) (world : World) =
             match evt.Type with

--- a/Nu/Nu/World/WorldModuleGame.fs
+++ b/Nu/Nu/World/WorldModuleGame.fs
@@ -1,4 +1,4 @@
-﻿// Nu Game Engine.
+// Nu Game Engine.
 // Required Notice:
 // Copyright (C) Bryan Edds.
 // Nu Game Engine is licensed under the Nu Game Engine Noncommercial License.
@@ -288,9 +288,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dCenter
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = World.getDisplayVirtualResolution world * Globals.Render.DisplayScalar
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dCenter = value
@@ -317,9 +318,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dRotation
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = World.getDisplayVirtualResolution world * Globals.Render.DisplayScalar
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dRotation = value
@@ -347,9 +349,10 @@ module WorldModuleGame =
             let gameState = World.getGameState game world
             let previous = gameState.Eye3dFieldOfView
             if previous <> value then
-                let viewportInterior = Viewport.makeInterior ()
-                let viewportExterior = Viewport.makeExterior ()
-                let viewportImposter = Viewport.makeImposter ()
+                let resolution = World.getDisplayVirtualResolution world * Globals.Render.DisplayScalar
+                let viewportInterior = Viewport.makeInteriorViewed resolution
+                let viewportExterior = Viewport.makeExteriorViewed resolution
+                let viewportImposter = Viewport.makeImposterViewed resolution
                 let gameState =
                     { gameState with
                         Eye3dFieldOfView = value
@@ -363,9 +366,8 @@ module WorldModuleGame =
 
         static member internal getGameEye3dAspectRatio game world =
             ignore<Game> game
-            ignore<World> world
-            single Constants.Render.DisplayVirtualResolution.X /
-            single Constants.Render.DisplayVirtualResolution.Y
+            let resolution = World.getDisplayVirtualResolution world
+            single resolution.X / single resolution.Y
 
         /// Get the current 3d eye field of view.
         static member getEye3dFieldOfView world =

--- a/Nu/Nu/World/WorldPrelude.fs
+++ b/Nu/Nu/World/WorldPrelude.fs
@@ -679,6 +679,11 @@ module internal AmbientState =
             Some fullScreen
         | _ -> None
 
+    let internal tryGetDisplaySize state =
+        state.SdlDepsOpt
+        |> Option.bind SdlDeps.tryGetDisplayMode
+        |> Option.map (fun displayMode -> v2i displayMode.w displayMode.h)
+
     let internal trySetWindowFullScreen fullScreen state =
         match state.SdlDepsOpt with
         | Some deps -> { state with SdlDepsOpt = Some (SdlDeps.trySetWindowFullScreen fullScreen deps) }

--- a/Nu/Nu/World/WorldTypes.fs
+++ b/Nu/Nu/World/WorldTypes.fs
@@ -1923,6 +1923,7 @@ and [<ReferenceEquality>] internal WorldExtension =
 
       // cache line 2
       WindowViewport : Viewport
+      DisplayVirtualResolution : Vector2i
       DestructionListRev : Simulant list
       LateBindingsInstances : LateBindingsInstances
       TryMakeEditContext : unit -> EditContext option


### PR DESCRIPTION
Move DisplayVirtualResolution into mutable Globals.Render and add World.setDisplayVirtualResolution, which resizes the window and synchronizes viewports and frusta at runtime.