### PR TITLE
Fix fluid particle cleanup across screens

### DIFF
--- a/Nu/Nu.Tests/FluidEmitterTests.fs
+++ b/Nu/Nu.Tests/FluidEmitterTests.fs
@@ -1,0 +1,85 @@
+// Nu Game Engine.
+// Required Notice:
+// Copyright (C) Bryan Edds.
+// Nu Game Engine is licensed under the Nu Game Engine Noncommercial License.
+// See https://github.com/bryanedds/Nu/blob/master/License.md.
+
+namespace Nu.Tests
+open System
+open System.Numerics
+open NUnit.Framework
+open Prime
+open Nu
+
+module FluidEmitterTests =
+
+    let private makeParticles () =
+        SArray.ofList
+            [ { FluidParticlePosition = Vector3 (0.0f, 0.0f, 0.0f)
+                FluidParticleVelocity = Vector3.Zero
+                FluidParticleConfig = "Water" }
+              { FluidParticlePosition = Vector3 (10.0f, 0.0f, 0.0f)
+                FluidParticleVelocity = Vector3.Zero
+                FluidParticleConfig = "Water" } ]
+
+    let [<Test>] ``Destroying a fluid emitter destroys its particle bodies.`` () =
+        let physicsEngine = Box2dNetPhysicsEngine.make Vector3.Zero
+        try
+            let emitterSource = { GsgAddress = atoa (stoa "FluidEmitterTests/Emitter") } :> Simulant
+            let emitterId = { FluidEmitterSource = emitterSource }
+            let particles = makeParticles ()
+            let descriptor = Box2dNetFluidEmitterDescriptor Box2dNetFluidEmitterDescriptor.defaultDescriptor
+            let createMessage =
+                { FluidEmitterId = emitterId
+                  FluidParticles = particles
+                  FluidEmitterDescriptor = descriptor }
+            let particleBody bodyIndex = { BodySource = emitterSource; BodyIndex = bodyIndex }
+            let particleRay = Ray3 (Vector3 (-20.0f, 0.0f, 0.0f), Vector3 (40.0f, 0.0f, 0.0f))
+            let rayCast () = physicsEngine.RayCast (particleRay, UInt64.MaxValue, UInt64.MaxValue, false)
+
+            physicsEngine.HandleMessage (CreateFluidEmitterMessage createMessage)
+            Assert.That (physicsEngine.GetFluidEmitterExists emitterId, Is.True)
+            let particleIntersections = rayCast ()
+            let actualParticleBodies = particleIntersections |> Array.map _.BodyShapeIntersected.BodyId |> Set.ofArray
+            let expectedParticleBodies = Set.ofList [particleBody 0; particleBody 1]
+            Assert.That (particleIntersections.Length, Is.EqualTo 2)
+            Assert.That (actualParticleBodies, Is.EqualTo expectedParticleBodies)
+
+            physicsEngine.HandleMessage (DestroyFluidEmitterMessage { FluidEmitterId = emitterId })
+            physicsEngine.HandleMessage (DestroyFluidEmitterMessage { FluidEmitterId = emitterId })
+
+            Assert.That (physicsEngine.GetFluidEmitterExists emitterId, Is.False)
+            Assert.That (rayCast (), Is.Empty)
+        finally
+            physicsEngine.CleanUp ()
+
+    let [<Test>] ``Resizing a fluid emitter destroys replaced particle bodies.`` () =
+        let physicsEngine = Box2dNetPhysicsEngine.make Vector3.Zero
+        try
+            let emitterSource = { GsgAddress = atoa (stoa "FluidEmitterTests/ResizedEmitter") } :> Simulant
+            let emitterId = { FluidEmitterSource = emitterSource }
+            let particles = makeParticles ()
+            let boxDescriptor = Box2dNetFluidEmitterDescriptor.defaultDescriptor
+            let descriptor = Box2dNetFluidEmitterDescriptor boxDescriptor
+            let createMessage =
+                { FluidEmitterId = emitterId
+                  FluidParticles = particles
+                  FluidEmitterDescriptor = descriptor }
+            let particleRay = Ray3 (Vector3 (-20.0f, 0.0f, 0.0f), Vector3 (40.0f, 0.0f, 0.0f))
+            let rayCast () = physicsEngine.RayCast (particleRay, UInt64.MaxValue, UInt64.MaxValue, false)
+            let resizedDescriptor =
+                Box2dNetFluidEmitterDescriptor
+                    { boxDescriptor with ParticlesMax = boxDescriptor.ParticlesMax + 1 }
+
+            physicsEngine.HandleMessage (CreateFluidEmitterMessage createMessage)
+            Assert.That ((rayCast ()).Length, Is.EqualTo 2)
+            physicsEngine.HandleMessage
+                (UpdateFluidEmitterMessage
+                    { FluidEmitterId = emitterId
+                      FluidEmitterDescriptor = resizedDescriptor })
+
+            Assert.That ((rayCast ()).Length, Is.EqualTo 2)
+            physicsEngine.HandleMessage (DestroyFluidEmitterMessage { FluidEmitterId = emitterId })
+            Assert.That (rayCast (), Is.Empty)
+        finally
+            physicsEngine.CleanUp ()

--- a/Nu/Nu.Tests/Nu.Tests.fsproj
+++ b/Nu/Nu.Tests/Nu.Tests.fsproj
@@ -16,6 +16,7 @@
 		<Compile Include="QuadtreeTests.fs" />
 		<Compile Include="OctreeTests.fs" />
 		<Compile Include="WorldTests.fs" />
+		<Compile Include="FluidEmitterTests.fs" />
 		<Compile Include="TraversalInterpolatedFacetTests.fs" />
         <None Include="AssetGraph.nuag" />
         <None Include="Overlayer.nuol" />

--- a/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
+++ b/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
@@ -192,6 +192,7 @@ type private Box2dNetFluidEmitter =
         elif fluidEmitter.FluidEmitterDescriptor.ParticlesMax <> descriptor.ParticlesMax then // update state array size
             let newEmitter = Box2dNetFluidEmitter.make descriptor fluidEmitter.PhysicsContextId fluidEmitter.BodySource
             Box2dNetFluidEmitter.addParticles (Seq.init fluidEmitter.StateCount (fun i -> fromFluid fluidEmitter.States[i]) |> _.GetEnumerator()) newEmitter
+            Box2dNetFluidEmitter.clearParticles fluidEmitter
             newEmitter
         elif fluidEmitter.FluidEmitterDescriptor.Configs <> descriptor.Configs then
             let newEmitter = { fluidEmitter with FluidEmitterDescriptor = descriptor }
@@ -1249,7 +1250,11 @@ type [<ReferenceEquality>] Box2dNetPhysicsEngine =
         | _ -> () // unsupported. Log?
 
     static member private destroyFluidEmitter (destroyFluidEmitterMessage : DestroyFluidEmitterMessage) physicsEngine =
-        physicsEngine.FluidEmitters.Remove destroyFluidEmitterMessage.FluidEmitterId |> ignore<bool>
+        match physicsEngine.FluidEmitters.TryGetValue destroyFluidEmitterMessage.FluidEmitterId with
+        | (true, emitter) ->
+            Box2dNetFluidEmitter.clearParticles emitter
+            physicsEngine.FluidEmitters.Remove destroyFluidEmitterMessage.FluidEmitterId |> ignore<bool>
+        | (false, _) -> ()
 
     static member private setBodyEnabled (setBodyEnabledMessage : SetBodyEnabledMessage) physicsEngine =
         match physicsEngine.Bodies.TryGetValue setBodyEnabledMessage.BodyId with


### PR DESCRIPTION
Fixes #1433

## Summary
- destroy all Box2D particle bodies before removing a fluid emitter
- clear replaced particle bodies when an emitter is resized
- keep repeated or missing-emitter destruction idempotent

## Tests
- `dotnet test Nu/Nu.Tests/Nu.Tests.fsproj --filter FullyQualifiedName~Nu.Tests.FluidEmitterTests` (2 passed)