### PR TITLE
Make fluid emitter integration messages optional

### DIFF
--- a/Nu/Nu.Tests/FluidEmitterTests.fs
+++ b/Nu/Nu.Tests/FluidEmitterTests.fs
@@ -1,0 +1,148 @@
+// Nu Game Engine.
+// Required Notice:
+// Copyright (C) Bryan Edds.
+// Nu Game Engine is licensed under the Nu Game Engine Noncommercial License.
+// See https://github.com/bryanedds/Nu/blob/master/License.md.
+
+namespace Nu.Tests
+open System.Numerics
+open NUnit.Framework
+open Prime
+open Nu
+
+module FluidEmitterTests =
+
+    let private particles =
+        SArray.singleton
+            { FluidParticlePosition = Vector3 (-50.0f, -50.0f, 0.0f)
+              FluidParticleVelocity = Vector3.Zero
+              FluidParticleConfig = "Water" }
+
+    let private integratesFluidEmitterMessage messagesEnabled =
+        Nu.init ()
+        let physicsEngine = Box2dNetPhysicsEngine.make Vector3.Zero
+        let fluidEmitterId = { FluidEmitterSource = Unchecked.defaultof<Simulant> }
+        let descriptor =
+            { Box2dNetFluidEmitterDescriptor.defaultDescriptor with
+                MessagesEnabled = messagesEnabled }
+        try
+            physicsEngine.HandleMessage
+                (CreateFluidEmitterMessage
+                    { FluidEmitterId = fluidEmitterId
+                      FluidParticles = particles
+                      FluidEmitterDescriptor = Box2dNetFluidEmitterDescriptor descriptor })
+            let result = physicsEngine.TryIntegrate (GameTime.ofUpdates 1L)
+            match result with
+            | Some messages ->
+                messages
+                |> Seq.exists (function
+                    | FluidEmitterMessage message -> message.FluidParticles.Length > 0
+                    | _ -> false)
+            | None -> false
+        finally
+            physicsEngine.CleanUp ()
+
+    let private integratesFluidEmitterMessagesAfterReenable () =
+        Nu.init ()
+        let physicsEngine = Box2dNetPhysicsEngine.make Vector3.Zero
+        let fluidEmitterId = { FluidEmitterSource = Unchecked.defaultof<Simulant> }
+        let descriptor = Box2dNetFluidEmitterDescriptor.defaultDescriptor
+        let sendDescriptor descriptor =
+            physicsEngine.HandleMessage
+                (UpdateFluidEmitterMessage
+                    { FluidEmitterId = fluidEmitterId
+                      FluidEmitterDescriptor = Box2dNetFluidEmitterDescriptor descriptor })
+        try
+            physicsEngine.HandleMessage
+                (CreateFluidEmitterMessage
+                    { FluidEmitterId = fluidEmitterId
+                      FluidParticles = particles
+                      FluidEmitterDescriptor = Box2dNetFluidEmitterDescriptor descriptor })
+            let integrate () =
+                let result = physicsEngine.TryIntegrate (GameTime.ofUpdates 1L)
+                match result with
+                | Some messages ->
+                    messages
+                    |> Seq.exists (function
+                        | FluidEmitterMessage message -> message.FluidParticles.Length > 0
+                        | _ -> false)
+                | None -> false
+            let initiallyEnabled = integrate ()
+            sendDescriptor { descriptor with MessagesEnabled = false }
+            let disabled = integrate ()
+            sendDescriptor { descriptor with MessagesEnabled = true }
+            let reenabled = integrate ()
+            (initiallyEnabled, disabled, reenabled)
+        finally
+            physicsEngine.CleanUp ()
+
+    let private removesOutOfBoundsParticleWhenMessagesDisabled () =
+        Nu.init ()
+        let physicsEngine = Box2dNetPhysicsEngine.make Vector3.Zero
+        let fluidEmitterId = { FluidEmitterSource = Unchecked.defaultof<Simulant> }
+        let descriptor =
+            { Box2dNetFluidEmitterDescriptor.defaultDescriptor with
+                MessagesEnabled = false }
+        let outOfBoundsParticles =
+            SArray.singleton
+                { FluidParticlePosition = Vector3 (100.0f, 100.0f, 0.0f)
+                  FluidParticleVelocity = Vector3.Zero
+                  FluidParticleConfig = "Water" }
+        let enabledDescriptor = { descriptor with MessagesEnabled = true }
+        try
+            physicsEngine.HandleMessage
+                (CreateFluidEmitterMessage
+                    { FluidEmitterId = fluidEmitterId
+                      FluidParticles = outOfBoundsParticles
+                      FluidEmitterDescriptor = Box2dNetFluidEmitterDescriptor descriptor })
+            let disabledResult = physicsEngine.TryIntegrate (GameTime.ofUpdates 1L)
+            physicsEngine.HandleMessage
+                (UpdateFluidEmitterMessage
+                    { FluidEmitterId = fluidEmitterId
+                      FluidEmitterDescriptor = Box2dNetFluidEmitterDescriptor enabledDescriptor })
+            let enabledResult = physicsEngine.TryIntegrate (GameTime.ofUpdates 1L)
+            let disabledHasNoFluidMessage =
+                match disabledResult with
+                | Some messages ->
+                    messages
+                    |> Seq.forall (function
+                        | FluidEmitterMessage _ -> false
+                        | _ -> true)
+                | None -> true
+            let enabledShowsParticleWasRemoved =
+                match enabledResult with
+                | Some messages ->
+                    messages
+                    |> Seq.exists (function
+                        | FluidEmitterMessage message ->
+                            message.FluidParticles.Length = 0 && message.OutOfBoundsParticles.Length = 0
+                        | _ -> false)
+                | None -> false
+            disabledHasNoFluidMessage && enabledShowsParticleWasRemoved
+        finally
+            physicsEngine.CleanUp ()
+
+    let [<Test>] ``Fluid emitter messages are enabled by default.`` () =
+        Assert.That (Box2dNetFluidEmitterDescriptor.defaultDescriptor.MessagesEnabled, Is.True)
+
+    let [<Test>] ``Fluid emitter message setting can be disabled and re-enabled.`` () =
+        let descriptor = Box2dNetFluidEmitterDescriptor.defaultDescriptor
+        let disabledDescriptor = { descriptor with MessagesEnabled = false }
+        let reenabledDescriptor = { disabledDescriptor with MessagesEnabled = true }
+        Assert.That (disabledDescriptor.MessagesEnabled, Is.False)
+        Assert.That (reenabledDescriptor.MessagesEnabled, Is.True)
+
+    let [<Test>] ``Enabled fluid emitter produces integration messages.`` () =
+        Assert.That (integratesFluidEmitterMessage true, Is.True)
+
+    let [<Test>] ``Disabled fluid emitter suppresses integration messages.`` () =
+        Assert.That (integratesFluidEmitterMessage false, Is.False)
+
+    let [<Test>] ``Re-enabled fluid emitter resumes integration messages.`` () =
+        let initiallyEnabled, disabled, reenabled = integratesFluidEmitterMessagesAfterReenable ()
+        Assert.That (initiallyEnabled, Is.True)
+        Assert.That (disabled, Is.False)
+        Assert.That (reenabled, Is.True)
+
+    let [<Test>] ``Disabled fluid emitter removes out-of-bounds particles without a message.`` () =
+        Assert.That (removesOutOfBoundsParticleWhenMessagesDisabled (), Is.True)

--- a/Nu/Nu.Tests/Nu.Tests.fsproj
+++ b/Nu/Nu.Tests/Nu.Tests.fsproj
@@ -16,6 +16,7 @@
 		<Compile Include="QuadtreeTests.fs" />
 		<Compile Include="OctreeTests.fs" />
 		<Compile Include="WorldTests.fs" />
+		<Compile Include="FluidEmitterTests.fs" />
 		<Compile Include="TraversalInterpolatedFacetTests.fs" />
         <None Include="AssetGraph.nuag" />
         <None Include="Overlayer.nuol" />

--- a/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
+++ b/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
@@ -454,22 +454,26 @@ type private Box2dNetFluidEmitter =
             let pos = B2Bodies.b2Body_GetPosition state.Body
             if aabb.lowerBound.X > pos.X || aabb.upperBound.X < pos.X || aabb.lowerBound.Y > pos.Y || aabb.upperBound.Y < pos.Y then
                 fluidEmitter.RemovedIndexes.Add i
-        let removedParticles =
-            if fluidEmitter.RemovedIndexes.Count = 0
-            then SArray.empty
-            else SArray.zeroCreate fluidEmitter.RemovedIndexes.Count
-        for j in 0 .. dec removedParticles.Length do
-            let i = fluidEmitter.RemovedIndexes[j]
-            removedParticles[j] <- fromFluid fluidEmitter.States[i]
-        Box2dNetFluidEmitter.processRemovedIndexes fluidEmitter
+        if fluidEmitter.FluidEmitterDescriptor.MessagesEnabled then
+            let removedParticles =
+                if fluidEmitter.RemovedIndexes.Count = 0
+                then SArray.empty
+                else SArray.zeroCreate fluidEmitter.RemovedIndexes.Count
+            for j in 0 .. dec removedParticles.Length do
+                let i = fluidEmitter.RemovedIndexes[j]
+                removedParticles[j] <- fromFluid fluidEmitter.States[i]
+            Box2dNetFluidEmitter.processRemovedIndexes fluidEmitter
 
-        // collect current particles
-        let particles = SArray.zeroCreate fluidEmitter.StateCount
-        for i in 0 .. dec fluidEmitter.StateCount do
-            particles[i] <- fromFluid fluidEmitter.States[i]
+            // collect current particles
+            let particles = SArray.zeroCreate fluidEmitter.StateCount
+            for i in 0 .. dec fluidEmitter.StateCount do
+                particles[i] <- fromFluid fluidEmitter.States[i]
 
-        // fin
-        struct (particles, removedParticles)
+            Some (struct (particles, removedParticles))
+        else
+            // Keep simulation state current without allocating integration payloads.
+            Box2dNetFluidEmitter.processRemovedIndexes fluidEmitter
+            None
 
     static member make descriptor physicsContextId bodySource =
         { FluidEmitterDescriptor = descriptor
@@ -1907,12 +1911,14 @@ type [<ReferenceEquality>] Box2dNetPhysicsEngine =
 
                 // collect fluid emitter results
                 for KeyValue (emitterId, emitter) in physicsEngine.FluidEmitters do
-                    let struct (particles, removedParticles) = Box2dNetFluidEmitter.postStep emitter
-                    physicsEngine.IntegrationMessages.Add
-                        (FluidEmitterMessage
-                            { FluidEmitterId = emitterId
-                              FluidParticles = particles
-                              OutOfBoundsParticles = removedParticles })
+                    match Box2dNetFluidEmitter.postStep emitter with
+                    | Some (struct (particles, removedParticles)) ->
+                        physicsEngine.IntegrationMessages.Add
+                            (FluidEmitterMessage
+                                { FluidEmitterId = emitterId
+                                  FluidParticles = particles
+                                  OutOfBoundsParticles = removedParticles })
+                    | None -> ()
                 
                 // collect joint breaks
                 for KeyValue (jointId, breakableJoint) in physicsEngine.BreakableJoints do

--- a/Nu/Nu/Physics/PhysicsPrelude.fs
+++ b/Nu/Nu/Physics/PhysicsPrelude.fs
@@ -649,6 +649,7 @@ type [<SymbolicExpansion>] FluidParticleConfig =
 /// Describes a particle-based 2d fluid emitter for Box2D.NET.
 type Box2dNetFluidEmitterDescriptor =
     { Enabled : bool
+      MessagesEnabled : bool
       ParticlesMax : int
       CellSize : single
       Configs : Map<string, FluidParticleConfig>
@@ -657,6 +658,7 @@ type Box2dNetFluidEmitterDescriptor =
 
     static member val defaultDescriptor =
         { Enabled = true
+          MessagesEnabled = true
           ParticlesMax = 20000
           CellSize = 10.0f
           Configs =

--- a/Nu/Nu/World/WorldFacets.fs
+++ b/Nu/Nu/World/WorldFacets.fs
@@ -1705,6 +1705,9 @@ module FluidEmitter2dFacetExtensions =
         member this.GetFluidEnabled world : bool = this.Get (nameof Entity.FluidEnabled) world
         member this.SetFluidEnabled (value : bool) world = this.Set (nameof Entity.FluidEnabled) value world
         member this.FluidEnabled = lens (nameof Entity.FluidEnabled) this this.GetFluidEnabled this.SetFluidEnabled
+        member this.GetFluidEmitterMessagesEnabled world : bool = this.Get (nameof Entity.FluidEmitterMessagesEnabled) world
+        member this.SetFluidEmitterMessagesEnabled (value : bool) world = this.Set (nameof Entity.FluidEmitterMessagesEnabled) value world
+        member this.FluidEmitterMessagesEnabled = lens (nameof Entity.FluidEmitterMessagesEnabled) this this.GetFluidEmitterMessagesEnabled this.SetFluidEmitterMessagesEnabled
         member this.GetFluidParticles world : FluidParticle SArray = this.Get (nameof Entity.FluidParticles) world
         member this.SetFluidParticles (value : FluidParticle SArray) world = this.Set (nameof Entity.FluidParticles) value world
         member this.FluidParticles = lens (nameof Entity.FluidParticles) this this.GetFluidParticles this.SetFluidParticles
@@ -1730,6 +1733,7 @@ type FluidEmitter2dFacet () =
                     ParticlesMax = entity.GetFluidParticlesMax world
                     CellSize = entity.GetFluidCellSize world
                     Enabled = entity.GetFluidEnabled world
+                    MessagesEnabled = entity.GetFluidEmitterMessagesEnabled world
                     SimulationBounds = (entity.GetBounds world).Box2
                     Gravity = entity.GetGravity world }
         | _ -> failwithumf ()
@@ -1744,6 +1748,7 @@ type FluidEmitter2dFacet () =
 
     static member Properties =
         [define Entity.FluidEnabled true
+         define Entity.FluidEmitterMessagesEnabled true
          define Entity.FluidParticles SArray.empty
          define Entity.FluidParticlesMax 20000
          define Entity.FluidCellSize 20.0f
@@ -1755,6 +1760,7 @@ type FluidEmitter2dFacet () =
         // update fluid emitter when any of the descriptor properties is set
         for event in
             [emitter.FluidEnabled.ChangeEvent
+             emitter.FluidEmitterMessagesEnabled.ChangeEvent
              emitter.FluidParticlesMax.ChangeEvent
              emitter.FluidCellSize.ChangeEvent
              emitter.Bounds.ChangeEvent


### PR DESCRIPTION
Fixes #1373

## Summary
- add a per-emitter `FluidEmitterMessagesEnabled` property that defaults to the existing enabled behavior
- skip allocating and populating fluid particle integration payload arrays while messages are disabled
- continue simulation and out-of-bounds particle cleanup, with runtime disable and re-enable support

## Tests
- `dotnet test Nu/Nu.Tests/Nu.Tests.fsproj --filter FullyQualifiedName~FluidEmitterTests` (6 passed)