### PR TITLE
Fix Sand Box 2d simulation physics

### DIFF
--- a/Nu/Nu.Gaia/Gaia.fs
+++ b/Nu/Nu.Gaia/Gaia.fs
@@ -1456,7 +1456,7 @@ DockSpace           ID=0x7C6B3D9B Window=0xA87D555D Pos=0,0 Size=1920,1080 Split
         let tryMakeEditContext = fun () -> Some (makeEditContext None None)
 
         // make the world
-        let world = World.make tryMakeEditContext sdlDeps worldConfig windowSize geometryViewport windowViewport plugin
+        let world = World.make tryMakeEditContext (SdlDependencies sdlDeps) worldConfig windowSize geometryViewport windowViewport plugin
 
         // initialize event filter as not to flood the log
         World.setEventFilter Constants.Gaia.EventFilter world

--- a/Nu/Nu.Tests/WorldTests.fs
+++ b/Nu/Nu.Tests/WorldTests.fs
@@ -27,7 +27,7 @@ module WorldTests =
             use _ = sdlDeps // bind explicitly to dispose automatically
             let windowViewport = Viewport.makeWindow1 windowSize
             let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
-            let world = World.make (constant None) sdlDeps worldConfig windowSize geometryViewport windowViewport (TestPlugin ())
+            let world = World.make (constant None) (SdlDependencies sdlDeps) worldConfig windowSize geometryViewport windowViewport (TestPlugin ())
             let result = World.runWithCleanUp (fun world -> world.UpdateTime < 1L) ignore ignore ignore ignore ignore (Some ignore) world
             Assert.Equal (Constants.Engine.ExitCodeSuccess, result)
         | Left _ -> Assert.Fail ()

--- a/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
+++ b/Nu/Nu/Physics/Box2dNetPhysicsEngine.fs
@@ -550,6 +550,14 @@ type [<ReferenceEquality>] Box2dNetPhysicsEngine =
         let struct (sin, cos) = MathF.SinCos halfAngle
         Quaternion (0.0f, 0.0f, sin, cos)
 
+    // NOTE: Box2D events can retain invalid shape ids after their shapes or bodies are destroyed.
+    static member private areEventShapesValid shapeA shapeB =
+        if B2Worlds.b2Shape_IsValid shapeA && B2Worlds.b2Shape_IsValid shapeB then
+            let bodyA = B2Shapes.b2Shape_GetBody shapeA
+            let bodyB = B2Shapes.b2Shape_GetBody shapeB
+            B2Worlds.b2Body_IsValid bodyA && B2Worlds.b2Body_IsValid bodyB
+        else false
+
     // NOTE: since sensor events don't report collision normals, we have to compute them ourselves.
     static member private computeCollisionNormalForSensors shapeA shapeB =
         let mutable transformA = B2Shapes.b2Shape_GetBody shapeA |> B2Bodies.b2Body_GetTransform
@@ -1984,45 +1992,49 @@ type [<ReferenceEquality>] Box2dNetPhysicsEngine =
                     // collect penetrations for non-sensors from begin contact events, which are performant but one time step late compared to the actual penetration
                     for i in 0 .. dec contacts.beginCount do
                         let penetration = &contacts.beginEvents[i]
-                        let bodyShapeA = (B2Shapes.b2Shape_GetUserData penetration.shapeIdA).GetRef<BodyShapeIndex> ()
-                        let bodyShapeB = (B2Shapes.b2Shape_GetUserData penetration.shapeIdB).GetRef<BodyShapeIndex> ()
-                        let normal =
-                            if B2Worlds.b2Contact_IsValid penetration.contactId then
-                                let contact = B2Contacts.b2Contact_GetData penetration.contactId
-                                v3 contact.manifold.normal.X contact.manifold.normal.Y 0.0f
-                            else
-                                let normal = Box2dNetPhysicsEngine.computeCollisionNormalForSensors penetration.shapeIdA penetration.shapeIdB
-                                v3 normal.X normal.Y 0.0f
-                        physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB; Normal = normal })
-                        physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA; Normal = -normal })
+                        if Box2dNetPhysicsEngine.areEventShapesValid penetration.shapeIdA penetration.shapeIdB then
+                            let bodyShapeA = (B2Shapes.b2Shape_GetUserData penetration.shapeIdA).GetRef<BodyShapeIndex> ()
+                            let bodyShapeB = (B2Shapes.b2Shape_GetUserData penetration.shapeIdB).GetRef<BodyShapeIndex> ()
+                            let normal =
+                                if B2Worlds.b2Contact_IsValid penetration.contactId then
+                                    let contact = B2Contacts.b2Contact_GetData penetration.contactId
+                                    v3 contact.manifold.normal.X contact.manifold.normal.Y 0.0f
+                                else
+                                    let normal = Box2dNetPhysicsEngine.computeCollisionNormalForSensors penetration.shapeIdA penetration.shapeIdB
+                                    v3 normal.X normal.Y 0.0f
+                            physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB; Normal = normal })
+                            physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA; Normal = -normal })
 
                 // collect separations for non-sensors that aren't ground separations by characters
                 for i in 0 .. dec contacts.endCount do
                     let separation = &contacts.endEvents[i]
                     physicsEngine.ContactsTracker.ExistingContacts.Remove (separation.shapeIdA, separation.shapeIdB) |> ignore
-                    let bodyShapeA = (B2Shapes.b2Shape_GetUserData separation.shapeIdA).GetRef<BodyShapeIndex> ()
-                    let bodyShapeB = (B2Shapes.b2Shape_GetUserData separation.shapeIdB).GetRef<BodyShapeIndex> ()
-                    physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB })
-                    physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA })
+                    if Box2dNetPhysicsEngine.areEventShapesValid separation.shapeIdA separation.shapeIdB then
+                        let bodyShapeA = (B2Shapes.b2Shape_GetUserData separation.shapeIdA).GetRef<BodyShapeIndex> ()
+                        let bodyShapeB = (B2Shapes.b2Shape_GetUserData separation.shapeIdB).GetRef<BodyShapeIndex> ()
+                        physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB })
+                        physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA })
 
                 // collect penetrations for sensors that aren't ground penetrations by characters
                 let sensorEvents = B2Worlds.b2World_GetSensorEvents physicsEngine.PhysicsContextId
                 for i in 0 .. dec sensorEvents.beginCount do
                     let sensorEvent = &sensorEvents.beginEvents[i]
-                    let bodyShapeA = (B2Shapes.b2Shape_GetUserData sensorEvent.sensorShapeId).GetRef<BodyShapeIndex> ()
-                    let bodyShapeB = (B2Shapes.b2Shape_GetUserData sensorEvent.visitorShapeId).GetRef<BodyShapeIndex> ()
-                    let normal = Box2dNetPhysicsEngine.computeCollisionNormalForSensors sensorEvent.sensorShapeId sensorEvent.visitorShapeId
-                    let normal = Vector3 (normal.X, normal.Y, 0.0f)
-                    physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB; Normal = normal })
-                    physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA; Normal = -normal })
+                    if Box2dNetPhysicsEngine.areEventShapesValid sensorEvent.sensorShapeId sensorEvent.visitorShapeId then
+                        let bodyShapeA = (B2Shapes.b2Shape_GetUserData sensorEvent.sensorShapeId).GetRef<BodyShapeIndex> ()
+                        let bodyShapeB = (B2Shapes.b2Shape_GetUserData sensorEvent.visitorShapeId).GetRef<BodyShapeIndex> ()
+                        let normal = Box2dNetPhysicsEngine.computeCollisionNormalForSensors sensorEvent.sensorShapeId sensorEvent.visitorShapeId
+                        let normal = v3 normal.X normal.Y 0.0f
+                        physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB; Normal = normal })
+                        physicsEngine.IntegrationMessages.Add (BodyPenetrationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA; Normal = -normal })
 
                 // collect separations for sensors that aren't ground separations by characters
                 for i in 0 .. dec sensorEvents.endCount do
                     let sensorEvent = &sensorEvents.endEvents[i]
-                    let bodyShapeA = (B2Shapes.b2Shape_GetUserData sensorEvent.sensorShapeId).GetRef<BodyShapeIndex> ()
-                    let bodyShapeB = (B2Shapes.b2Shape_GetUserData sensorEvent.visitorShapeId).GetRef<BodyShapeIndex> ()
-                    physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB })
-                    physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA })
+                    if Box2dNetPhysicsEngine.areEventShapesValid sensorEvent.sensorShapeId sensorEvent.visitorShapeId then
+                        let bodyShapeA = (B2Shapes.b2Shape_GetUserData sensorEvent.sensorShapeId).GetRef<BodyShapeIndex> ()
+                        let bodyShapeB = (B2Shapes.b2Shape_GetUserData sensorEvent.visitorShapeId).GetRef<BodyShapeIndex> ()
+                        physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeA; BodyShapeTarget = bodyShapeB })
+                        physicsEngine.IntegrationMessages.Add (BodySeparationMessage { BodyShapeSource = bodyShapeB; BodyShapeTarget = bodyShapeA })
                     
                 // collect transforms that aren't by characters nor fluid particles
                 let bodyEvents = B2Worlds.b2World_GetBodyEvents physicsEngine.PhysicsContextId

--- a/Nu/Nu/Render/RendererProcess.fs
+++ b/Nu/Nu/Render/RendererProcess.fs
@@ -64,6 +64,28 @@ type RendererProcess =
         abstract Terminate : unit -> unit
         end
 
+/// A lifecycle-safe renderer for headless worlds. It accepts all render traffic without creating SDL or Vulkan resources.
+type StubRendererProcess () =
+    let mutable started = false
+    let mutable terminated = false
+    interface RendererProcess with
+        member _.Start _ _ _ _ =
+            if terminated then invalidOp "Cannot start a terminated stub renderer."
+            started <- true
+        member _.Renderer3dConfig = Renderer3dConfig.defaultConfig
+        member _.TryGetImGuiTextureId _ = ValueNone
+        member _.EnqueueMessage3d _ = if not started || terminated then invalidOp "Stub renderer is not started."
+        member _.RenderStaticModelFast (_, _, _, _, _, _, _, _, _, _) = ()
+        member _.RenderStaticModelSurfaceFast (_, _, _, _, _, _, _, _, _, _, _) = ()
+        member _.RenderAnimatedModelFast (_, _, _, _, _, _, _, _, _, _, _, _) = ()
+        member _.EnqueueMessage2d _ = if not started || terminated then invalidOp "Stub renderer is not started."
+        member _.RenderLayeredSpriteFast (_, _, _, _, _, _, _, _, _, _, _) = ()
+        member _.EnqueueMessageImGui _ = if not started || terminated then invalidOp "Stub renderer is not started."
+        member _.ClearMessages () = ()
+        member _.SubmitMessages _ _ _ _ _ _ _ _ _ _ _ _ = ()
+        member _.RequestSwap () = ()
+        member _.Terminate () = terminated <- true
+
 /// A non-threaded render process.
 type RendererInline (windowProperties) =
 

--- a/Nu/Nu/World/World.fs
+++ b/Nu/Nu/World/World.fs
@@ -151,6 +151,14 @@ module Platform =
             configureJoltFramework ()
             configureVmaFramework ()
 
+        let configureMacNativeLibraries () =
+            configureFrameworkNativeLibraries ()
+            if Constants.Vulkan.MoltenVk then
+                // NOTE: SDL resolves a bare dylib name through the host loader's search paths rather than the managed
+                // executable directory, so anchor MoltenVK to the latter to avoid test-runner / IDE working directories.
+                let moltenVkPath = PathF.Combine (AppContext.BaseDirectory, "libMoltenVK.dylib")
+                SDL.SDL3.SDL_SetHint (SDL.SDL3.SDL_HINT_VULKAN_LIBRARY, moltenVkPath) |> ignore<SDL.SDLBool>
+
         [<RequireQualifiedAccess>]
         module iOS =
 
@@ -248,7 +256,7 @@ type Nu () =
                 Platform.Android.configureAndroidNativeLibraries ()
                 Log.init None // disable Nu's default file log because the Android asset pack directory should be treated as read-only for incremental updates to work - https://developer.android.com/reference/com/google/android/play/core/assetpacks/AssetPackManager#getpacklocation
             elif OperatingSystem.IsMacOS () then
-                Platform.Apple.configureFrameworkNativeLibraries ()
+                Platform.Apple.configureMacNativeLibraries ()
 
             // ensure the current culture is invariate
             Thread.CurrentThread.CurrentCulture <- Globalization.CultureInfo.InvariantCulture

--- a/Nu/Nu/World/World.fs
+++ b/Nu/Nu/World/World.fs
@@ -19,6 +19,22 @@ open System.Threading
 open SDL
 open Prime
 
+[<ReferenceEquality>]
+/// Explicit dependencies supplied to a world; the world starts and owns them except optional SDL dependencies.
+type WorldDependencies =
+    { SdlDepsOpt : SdlDeps option
+      ImGui : ImGui
+      PhysicsEngine2d : PhysicsEngine
+      PhysicsEngine3d : PhysicsEngine
+      RendererPhysics3dOpt : JoltPhysicsSharp.DebugRenderer option
+      RendererProcess : RendererProcess
+      AudioPlayer : AudioPlayer
+      CursorClient : CursorClient }
+
+type WorldDependencySource =
+    | SdlDependencies of SdlDeps
+    | SuppliedDependencies of WorldDependencies
+
 /// GC event listener. Currently just logs whenever an object larger than 85k is allocated to notify user of possible
 /// LOH churn.
 type private GcEventListener () =
@@ -532,8 +548,62 @@ module WorldModule4 =
             // fin
             world
 
-        /// Make the world with the given SDL dependencies.
-        static member make tryMakeEditContext sdlDeps config windowSize geometryViewport (windowViewport : Viewport) (plugin : NuPlugin) =
+        /// Make a world from explicitly supplied dependencies. The renderer is started by this method; all supplied
+        /// subsystems become world-owned except optional SDL dependencies, which remain caller-owned.
+        static member private makeWithDependenciesCore tryMakeEditContext worldConfig windowSize geometryViewport (windowViewport : Viewport) (plugin : NuPlugin) (dependencies : WorldDependencies) =
+            let eventGraph =
+                let eventTracing = Constants.Engine.EventTracing
+                let eventTracerOpt = if eventTracing then Some (Log.custom "Event") else None
+                let globalSimulantGeneralized = { GsgAddress = atoa Game.GameAddress }
+                let eventConfig = if worldConfig.Imperative then Imperative else Functional
+                EventGraph.make eventTracerOpt Constants.Engine.EventFilter globalSimulantGeneralized eventConfig
+            let pluginAssemblyNamePredicate =
+                fun (assemblyName : AssemblyName) ->
+                    not (assemblyName.Name.StartsWith "System.") && not (assemblyName.Name.StartsWith "FSharp.") &&
+                    not (assemblyName.Name.StartsWith "Prime.") && not (assemblyName.Name.StartsWith "Nu.") &&
+                    assemblyName.Name <> "Prime" && assemblyName.Name <> "Nu" && assemblyName.Name <> "netstandard" &&
+                    not (assemblyName.Name.StartsWith "ppy.SDL3")
+            let pluginAssembly = plugin.GetType().Assembly
+            let pluginAssemblies =
+                Array.cons pluginAssembly (Reflection.loadReferencedAssembliesTransitively pluginAssemblyNamePredicate pluginAssembly)
+            let pluginFacets = plugin.Birth<Facet> pluginAssemblies
+            let pluginEntityDispatchers = plugin.Birth<EntityDispatcher> pluginAssemblies
+            let pluginGroupDispatchers = plugin.Birth<GroupDispatcher> pluginAssemblies
+            let pluginScreenDispatchers = plugin.Birth<ScreenDispatcher> pluginAssemblies
+            let pluginGameDispatchers = plugin.Birth<GameDispatcher> pluginAssemblies
+            let defaultGameDispatcher = World.makeDefaultGameDispatcher ()
+            let lateBindingsInstances =
+                { Facets = Map.addMany pluginFacets (World.makeDefaultFacets ())
+                  EntityDispatchers = Map.addMany pluginEntityDispatchers (World.makeDefaultEntityDispatchers ())
+                  GroupDispatchers = Map.addMany pluginGroupDispatchers (World.makeDefaultGroupDispatchers ())
+                  ScreenDispatchers = Map.addMany pluginScreenDispatchers (World.makeDefaultScreenDispatchers ())
+                  GameDispatchers = Map.addMany pluginGameDispatchers (Map.ofList [defaultGameDispatcher]) }
+            let activeGameDispatcher =
+                match Array.tryHead pluginGameDispatchers with
+                | Some (_, dispatcher) -> dispatcher
+                | None -> GameDispatcher ()
+            let imGui = dependencies.ImGui
+            let physicsEngine2d = dependencies.PhysicsEngine2d
+            let physicsEngine3d = dependencies.PhysicsEngine3d
+            let rendererProcess = dependencies.RendererProcess
+            rendererProcess.Start imGui.Fonts (dependencies.SdlDepsOpt |> Option.bind SdlDeps.getWindowOpt) geometryViewport windowViewport
+            let audioPlayer = dependencies.AudioPlayer
+            let cursorClient = dependencies.CursorClient
+            let quadtree = Quadtree.make Constants.Engine.QuadtreeDepth Constants.Engine.QuadtreeSize
+            let octree = Octree.make Constants.Engine.OctreeDepth Constants.Engine.OctreeSize
+            let jobGraph =
+                if Constants.Engine.RunSynchronously then JobGraphInline () :> JobGraph
+                else JobGraphParallel (TimeSpan.FromSeconds 0.5) :> JobGraph
+            let world =
+                World.makePlus tryMakeEditContext plugin eventGraph jobGraph geometryViewport windowViewport
+                    lateBindingsInstances quadtree octree worldConfig dependencies.SdlDepsOpt imGui physicsEngine2d physicsEngine3d dependencies.RendererPhysics3dOpt
+                    rendererProcess audioPlayer cursorClient activeGameDispatcher
+            if World.getWindowSizeOtherwiseViewportSize world <> windowSize then World.processWindowResize world
+            for (key, value) in plugin.MakeKeyedValues world do World.addKeyedValue key value world
+            World.registerGame Game world
+            world
+
+        static member private makeSdl tryMakeEditContext sdlDeps config windowSize geometryViewport (windowViewport : Viewport) (plugin : NuPlugin) =
 
             // compute window properties
             let windowProperties =
@@ -657,13 +727,19 @@ module WorldModule4 =
             World.registerGame Game world
             world
 
+        /// Make a world using either caller-owned SDL dependencies or explicitly supplied dependencies.
+        static member make tryMakeEditContext dependencySource worldConfig windowSize geometryViewport windowViewport plugin =
+            match dependencySource with
+            | SdlDependencies sdlDeps -> World.makeSdl tryMakeEditContext sdlDeps worldConfig windowSize geometryViewport windowViewport plugin
+            | SuppliedDependencies dependencies -> World.makeWithDependenciesCore tryMakeEditContext worldConfig windowSize geometryViewport windowViewport plugin dependencies
+
         /// Run the game engine, initializing dependencies as indicated by WorldConfig, and returning exit code upon
         /// termination.
         static member runPlus tryMakeEditContext runWhile preProcess perProcess postProcess imGuiProcess imGuiPostProcess firstFrameCallback worldConfig windowSize geometryViewport windowViewport plugin =
             match SdlDeps.tryMake worldConfig.SdlConfig worldConfig.Accompanied windowSize with
             | Right sdlDeps ->
                 use _ = sdlDeps
-                let world = World.make tryMakeEditContext sdlDeps worldConfig windowSize geometryViewport windowViewport plugin
+                let world = World.make tryMakeEditContext (SdlDependencies sdlDeps) worldConfig windowSize geometryViewport windowViewport plugin
                 World.runWithCleanUp runWhile preProcess perProcess postProcess imGuiProcess imGuiPostProcess (Some firstFrameCallback) world
             | Left error -> Log.error error; Constants.Engine.ExitCodeFailure
 

--- a/Nu/Nu/World/World.fs
+++ b/Nu/Nu/World/World.fs
@@ -153,11 +153,10 @@ module Platform =
 
         let configureMacNativeLibraries () =
             configureFrameworkNativeLibraries ()
-            if Constants.Vulkan.MoltenVk then
-                // NOTE: SDL resolves a bare dylib name through the host loader's search paths rather than the managed
-                // executable directory, so anchor MoltenVK to the latter to avoid test-runner / IDE working directories.
-                let moltenVkPath = PathF.Combine (AppContext.BaseDirectory, "libMoltenVK.dylib")
-                SDL.SDL3.SDL_SetHint (SDL.SDL3.SDL_HINT_VULKAN_LIBRARY, moltenVkPath) |> ignore<SDL.SDLBool>
+            // NOTE: SDL needs the Vulkan loader, not an ICD such as MoltenVK; anchor the bundled loader to the
+            // managed executable directory because bare dylib lookup depends on the host search paths.
+            let vulkanLoaderPath = PathF.Combine (AppContext.BaseDirectory, "libvulkan.1.dylib")
+            SDL.SDL3.SDL_SetHint (SDL.SDL3.SDL_HINT_VULKAN_LIBRARY, vulkanLoaderPath) |> ignore<SDL.SDLBool>
 
         [<RequireQualifiedAccess>]
         module iOS =

--- a/Projects/Sand Box 2d/FluidSim.fs
+++ b/Projects/Sand Box 2d/FluidSim.fs
@@ -264,6 +264,7 @@ type FluidSimDispatcher () =
                          Entity.StaticImage .= renders[toolName].Image
                          Entity.Color .= renders[toolName].Color
                      | Bubble ->
+                         Entity.InsetOpt .= Some Sandbox2dGeometry.BubbleImageInset
                          Entity.StaticImage .= Assets.Gameplay.BubbleImage
                      | Line ->
                          Entity.Size .= v3 25f 2f 0f
@@ -386,6 +387,7 @@ type FluidSimDispatcher () =
                     World.doOrbBody2d "Bubble"
                         [Entity.Position @= mousePosition.V3
                          Entity.Size @= v3Dup (Sandbox2dGeometry.bubbleDiameter (fluidSim.GetMouseBubbleSize world))
+                         Entity.InsetOpt .= Some Sandbox2dGeometry.BubbleImageInset
                          Entity.StaticImage .= Assets.Gameplay.BubbleImage] world |> ignore
                 | (Bubble, (false, _)) when World.isMouseButtonReleased MouseLeft world -> // the feeler detects only presses, not releases.
                     // reset size when mouse left button is just released

--- a/Projects/Sand Box 2d/RaceCourse.fs
+++ b/Projects/Sand Box 2d/RaceCourse.fs
@@ -21,19 +21,8 @@ type RaceCourseDispatcher () =
     static let RaceCourseScale = Sandbox2dGeometry.RaceCourseScale
     static let CarMotorSpeedMax = Sandbox2dGeometry.CarMotorSpeedMax
 
-    static let RaceTrackContour =
-        // unlike the border in ToyBox which is a closed contour, an open contour used here defines ghost vertices at the ends.
-        // they are used to connect to other contours at their second and second-to-last links for seamless contour transitions
-        // and avoiding ghost collisions. here, we just set the ghost vertices to be the same as the second and second-to-last positions.
-        [|v2 -20f 5f (*Ghost vertex*); v2 -20f 5f; v2 -20f 0f; v2 20f 0f; v2 25f 0.25f; v2 30f 1f; v2 35f 4f; v2 40f 0f; v2 45f 0f;
-          v2 50f -1f; v2 55f -2f; v2 60f -2f; v2 65f -1.25f; v2 70f 0f; v2 75f 0.3f; v2 80f 1.5f; v2 85f 3.5f;
-          v2 90f 0f; v2 95f -0.5f; v2 100f -1f; v2 105f -2f; v2 110f -2.5f; v2 115f -1.3f; v2 120f 0f; v2 160f 0f;
-          v2 159f -10f; v2 201f -10f; v2 200f 0f; v2 240f 0f; v2 250f 5f; v2 250f -10f; v2 270f -10f; v2 270f 0f;
-          v2 310f 0f; v2 310f 5f; v2 310f 5f (*Ghost vertex*)|]
-        |> Array.rev // IMPORTANT: ContourShape only collides on the right hand side of each link!
-
     static let RaceTrackPoints =
-        RaceTrackContour
+        Sandbox2dGeometry.RaceTrackContour
         |> Array.map ((*) RaceCourseScale)
         |> Array.map _.V3
 
@@ -50,12 +39,7 @@ type RaceCourseDispatcher () =
         Sandbox2dGeometry.carSize.V3
 
     static let CarSpawnPosition =
-        let rearWheelOffsetY = Sandbox2dGeometry.carWheelOffset Sandbox2dGeometry.CarRearWheelModelOffset 0f |> _.Y
-        v3 0f (Sandbox2dGeometry.carSpawnHeight 0f rearWheelOffsetY (RaceCourseScale / 2f)) 0f
-
-    static let computeWheelOffset (position : Vector2) rotation =
-        Sandbox2dGeometry.carWheelOffset position rotation
-        |> fun position -> position.V3
+        (Sandbox2dGeometry.CarContourBounds.Center * RaceCourseScale).V3 + v3 0f RaceCourseScale 0f
 
     // here we define default property values
     static member Properties =
@@ -81,6 +65,7 @@ type RaceCourseDispatcher () =
             World.doBlockBody2d "Race Track"
                 [Entity.Size .= v3 1f 1f 0f
                  Entity.BodyShape .= ContourShape { Links = RaceTrackPoints; Closed = false; TransformOpt = None; PropertiesOpt = None }
+                 Entity.Friction .= 0.6f
                  Entity.CollisionDetection .= Continuous] world |> ignore // keep car wheels above ground
             for (p1, p2) in Array.pairwise RaceTrackPoints do
                 World.doStaticSprite $"Race Track {p1} -> {p2}"
@@ -101,21 +86,19 @@ type RaceCourseDispatcher () =
                           TransformOpt = None
                           PropertiesOpt = None }
                  Entity.StaticImage .= Assets.Gameplay.CarImage
-                 Entity.Substance .= Density Sandbox2dGeometry.CarChassisDensity
+                 Entity.Substance .= Density (Sandbox2dGeometry.CarChassisDensity * Sandbox2dGeometry.SourceMassScale)
                  Entity.Friction .= Sandbox2dGeometry.CarChassisFriction] world |> ignore
             let car = world.DeclaredEntity
 
             // declare wheels (and joints)
             for (relation, position, density, frequency, friction, maxTorque, isMotor) in Sandbox2dGeometry.CarWheelSpecs do
-                let carRotation = (car.GetRotation world).Angle2d
-                let wheelOffset = computeWheelOffset position carRotation
-                let wheelPosition = CarSpawnPosition + wheelOffset
+                let wheelPosition = v3 position.X position.Y 0f * RaceCourseScale
                 World.doBallBody2d $"Wheel {relation}"
                     [Entity.Position |= wheelPosition
                      Entity.Rotation |= quatIdentity
                      Entity.Size .= v3One * RaceCourseScale
                      Entity.StaticImage .= Assets.Gameplay.WheelImage
-                     Entity.Substance .= Density (density * 2f)
+                     Entity.Substance .= Density (density * Sandbox2dGeometry.SourceMassScale)
                      Entity.Friction .= friction
                      Entity.Elevation .= 0.1f] world |> ignore
                 let (bodyJointId, _) =
@@ -135,14 +118,14 @@ type RaceCourseDispatcher () =
                             jointDef.enableSpring <- true
                             jointDef.hertz <- frequency
                             jointDef.dampingRatio <- Sandbox2dGeometry.CarWheelDampingRatio
-                            jointDef.maxMotorTorque <- maxTorque // this won't apply without enableMotor = true, which we'll set later via World.setBodyJointMotorEnabled
+                            jointDef.maxMotorTorque <- maxTorque * Sandbox2dGeometry.SourceTorqueScale
                             B2Joints.b2CreateWheelJoint (world, &jointDef) }
                          Entity.BodyJointTarget .= Address.makeFromString "^/Car"
                          Entity.BodyJointTarget2 .= Address.makeFromString $"^/Wheel {relation}"
                          Entity.CollideConnected .= false] world
                 if raceCourse.GetSelected world && isMotor then
                     let acceleration = raceCourse.GetCarAcceleration world
-                    let motorSpeed = single (sign acceleration) * Math.SmoothStep (0f, CarMotorSpeedMax, abs acceleration)
+                    let motorSpeed = Sandbox2dGeometry.carMotorSpeed acceleration
                     World.setBodyJointMotorSpeed motorSpeed bodyJointId world
                     World.setBodyJointMotorEnabled (abs motorSpeed >= CarMotorSpeedMax * 0.06f) bodyJointId world
 
@@ -157,13 +140,15 @@ type RaceCourseDispatcher () =
                 else raceCourse.CarAcceleration.Map (fun a -> a - single (sign a) * 2.0f * world.ClockDelta) world
 
             // declare teeter totter
-            World.doBoxBody2d "Teeter Board"
-                [Entity.Position |= v3 140f 1f 0f * RaceCourseScale
-                 Entity.Rotation |= Quaternion.CreateFromAngle2d 0.15f
-                 Entity.Size .= v3 20f 0.5f 0f * RaceCourseScale
-                 Entity.StaticImage .= Assets.Default.Paddle
-                 Entity.Substance .= Density 1f
-                 Entity.CollisionDetection .= Continuous] world |> ignore
+            let teeterBodyId, _ =
+                World.doBoxBody2d "Teeter Board"
+                    [Entity.Position |= v3 140f Sandbox2dGeometry.TeeterCenterY 0f * RaceCourseScale
+                     Entity.Rotation |= Quaternion.CreateFromAngle2d Sandbox2dGeometry.TeeterInitialAngle
+                     Entity.Size .= v3 (2f * Sandbox2dGeometry.TeeterBoardHalfLength) (2f * Sandbox2dGeometry.TeeterBoardHalfThickness) 0f * RaceCourseScale
+                     Entity.StaticImage .= Assets.Default.Paddle
+                     Entity.Substance .= Density Sandbox2dGeometry.SourceMassScale
+                     Entity.CollisionDetection .= Continuous] world
+            let teeterInitializing = world.DeclaredInitializing
             World.doBodyJoint2d "Teeter Joint"
                 [Entity.BodyJoint |= Box2dNetBodyJoint { CreateBodyJoint = fun _ _ a b world ->
                     let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
@@ -171,20 +156,27 @@ type RaceCourseDispatcher () =
                     jointDef.``base``.bodyIdB <- b
                     jointDef.``base``.localFrameA.p <- B2Bodies.b2Body_GetLocalPoint (a, B2Bodies.b2Body_GetPosition b)
                     jointDef.enableLimit <- true // required for lowerAngle and upperAngle to take effect
-                    jointDef.lowerAngle <- -8.0f * MathF.PI / 180.0f
-                    jointDef.upperAngle <- 8.0f * MathF.PI / 180.0f
+                    jointDef.lowerAngle <- -Sandbox2dGeometry.TeeterAngleLimit
+                    jointDef.upperAngle <- Sandbox2dGeometry.TeeterAngleLimit
                     B2Joints.b2CreateRevoluteJoint (world, &jointDef) }
                  Entity.BodyJointTarget .= Address.makeFromString "^/Race Track"
                  Entity.BodyJointTarget2 .= Address.makeFromString "^/Teeter Board"
                  Entity.CollideConnected .= false] world |> ignore
+            if teeterInitializing then
+                World.applyBodyAngularImpulse (v3 0f 0f Sandbox2dGeometry.TeeterAngularImpulse) teeterBodyId world
 
             // declare bridge
+            let bridgeEndpoints =
+                Array.init Sandbox2dGeometry.BridgeLinkCount (fun i ->
+                    v3 (160f + 2f * single i) -0.125f 0f, v3 (160f + 2f * single (i + 1)) -0.125f 0f)
+                |> Array.map (fun (a, b) -> a * RaceCourseScale, b * RaceCourseScale)
             for i in 0 .. Sandbox2dGeometry.BridgeLinkCount do
                 if i < Sandbox2dGeometry.BridgeLinkCount then
+                    let endpoint1, endpoint2 = bridgeEndpoints[i]
                     World.doBoxBody2d $"Bridge {i}"
-                        [Entity.Position |= v3 (161f + (Sandbox2dGeometry.BridgeLinkPitch / RaceCourseScale) * single i) -0.125f 0f * RaceCourseScale
+                        [Entity.Position |= (endpoint1 + endpoint2) / 2f
                          Entity.Rotation |= quatIdentity
-                         Entity.Size .= v3 2f 0.25f 0f * RaceCourseScale
+                         Entity.Size .= v3 (endpoint2 - endpoint1).Magnitude Sandbox2dGeometry.BridgeLinkThickness 0f
                          Entity.Friction .= 0.6f
                          Entity.StaticImage .= Assets.Default.Paddle
                          Entity.CollisionDetection .= Continuous
@@ -193,9 +185,9 @@ type RaceCourseDispatcher () =
                     [Entity.BodyJoint |= Box2dNetBodyJoint {
                         CreateBodyJoint = fun _ toPhysicsV2 a b world ->
                             let p =
-                                if i < Sandbox2dGeometry.BridgeLinkCount
-                                then B2Bodies.b2Body_GetPosition b - toPhysicsV2 (v3 (Sandbox2dGeometry.BridgeLinkPitch / 2f) 0f 0f)
-                                else B2Bodies.b2Body_GetPosition a + toPhysicsV2 (v3 (Sandbox2dGeometry.BridgeLinkPitch / 2f) 0f 0f)
+                                if i = 0 then toPhysicsV2 (fst bridgeEndpoints[0])
+                                elif i = Sandbox2dGeometry.BridgeLinkCount then toPhysicsV2 (snd bridgeEndpoints[i - 1])
+                                else toPhysicsV2 (snd bridgeEndpoints[i - 1])
                             let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
                             jointDef.``base``.bodyIdA <- a
                             jointDef.``base``.bodyIdB <- b
@@ -224,7 +216,7 @@ type RaceCourseDispatcher () =
             World.endGroup world
             
             // reset gravity from ToyBox
-            World.setGravity2d (World.getGravityDefault2d world) world
+            World.setGravity2d (v3 0f Sandbox2dGeometry.SourceGravity 0f) world
 
             // process car camera as the last task
             // menu offset (X = 60) + car lookahead (X = 40) + make objects spawn above ground (Y = 60)

--- a/Projects/Sand Box 2d/Sand Box 2d.fsproj
+++ b/Projects/Sand Box 2d/Sand Box 2d.fsproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
+		<IsTestProject>true</IsTestProject>
         <GenerateProgramFile>False</GenerateProgramFile> <!-- TODO: move into Nu.Targets for everything? -->
 	</PropertyGroup>
 

--- a/Projects/Sand Box 2d/SandBox2dTests.fs
+++ b/Projects/Sand Box 2d/SandBox2dTests.fs
@@ -7,382 +7,414 @@
 namespace SandBox2d
 open System
 open System.Numerics
-open Box2D.NET
 open NUnit.Framework
+open Prime
 open Nu
+
 module Tests =
-
-    type private FixtureMetrics =
-        { InitialEnergy : single
-          PeakEnergy : single
-          FinalAnchorError : single
-          PeakAnchorError : single }
-
-    let private Meter = Constants.Engine.Meter2d
-
-    let private toPhysics (position : Vector3) =
-        B2Vec2 (position.X / Meter, position.Y / Meter)
-
-    let private step count world =
-        for _ in 1 .. count do
-            B2Worlds.b2World_Step (world, 1f / 60f, Constants.Physics.Collision2dSteps)
-
-    let private createWorld1 gravity =
-        let mutable definition = B2Types.b2DefaultWorldDef ()
-        definition.gravity <- gravity
-        B2Worlds.b2CreateWorld &definition
-
-    let private createWorld () =
-        let mutable definition = B2Types.b2DefaultWorldDef ()
-        definition.gravity <- B2Vec2 (0f, -9.80665f)
-        B2Worlds.b2CreateWorld &definition
-
-    let private createBody4 world bodyType x y =
-        let mutable definition = B2Types.b2DefaultBodyDef ()
-        definition.``type`` <- bodyType
-        definition.position <- B2Vec2 (x, y)
-        B2Bodies.b2CreateBody (world, &definition)
-
-    let private createBody2 world position =
-        let mutable definition = B2Types.b2DefaultBodyDef ()
-        definition.``type`` <- B2BodyType.b2_dynamicBody
-        definition.position <- position
-        B2Bodies.b2CreateBody (world, &definition)
-
-    let private createBody3 world bodyType position =
-        let mutable definition = B2Types.b2DefaultBodyDef ()
-        definition.``type`` <- bodyType
-        definition.position <- position
-        B2Bodies.b2CreateBody (world, &definition)
-
-    let private createWheel (world : B2WorldId) (car : B2BodyId) (spawnPosition : B2Vec2)
-        (position, density, frequency, friction, maxTorque, isMotor) =
-        let offset = Sandbox2dGeometry.carWheelOffset position 0f / Meter
-        let wheelPosition = B2Vec2 (spawnPosition.X + offset.X, spawnPosition.Y + offset.Y)
-        let wheel = createBody3 world B2BodyType.b2_dynamicBody wheelPosition
-        let mutable shapeDefinition = B2Types.b2DefaultShapeDef ()
-        shapeDefinition.density <- density * 2f
-        shapeDefinition.material.friction <- friction
-        let mutable circle = B2Circle (B2MathFunction.b2Vec2_zero, Sandbox2dGeometry.CarWheelRadius / Meter)
-        B2Shapes.b2CreateCircleShape (wheel, &shapeDefinition, &circle) |> ignore
-
-        let mutable jointDefinition = B2Joints.b2DefaultWheelJointDef ()
-        jointDefinition.``base``.bodyIdA <- car
-        jointDefinition.``base``.bodyIdB <- wheel
-        jointDefinition.``base``.localFrameA.p <- B2Bodies.b2Body_GetLocalPoint (car, wheelPosition)
-        jointDefinition.``base``.localFrameB.p <- B2Bodies.b2Body_GetLocalPoint (wheel, wheelPosition)
-        jointDefinition.``base``.localFrameA.q <- B2MathFunction.b2MakeRot MathF.PI_OVER_2
-        jointDefinition.enableSpring <- true
-        jointDefinition.hertz <- frequency
-        jointDefinition.dampingRatio <- Sandbox2dGeometry.CarWheelDampingRatio
-        jointDefinition.enableMotor <- isMotor
-        jointDefinition.motorSpeed <- 0f
-        jointDefinition.maxMotorTorque <- maxTorque
-        let jointId = B2Joints.b2CreateWheelJoint (world, &jointDefinition)
-        (wheel, jointId)
-
-    let private addBox5 body halfWidth halfHeight density friction =
-        let mutable definition = B2Types.b2DefaultShapeDef ()
-        definition.density <- density
-        definition.material.friction <- friction
-        let mutable polygon = B2Geometries.b2MakeBox (halfWidth, halfHeight)
-        B2Shapes.b2CreatePolygonShape (body, &definition, &polygon) |> ignore
-
-    let private addBox4 body halfWidth halfHeight density =
-        let mutable shapeDefinition = B2Types.b2DefaultShapeDef ()
-        shapeDefinition.density <- density
-        let mutable polygon = B2Geometries.b2MakeBox (halfWidth, halfHeight)
-        B2Shapes.b2CreatePolygonShape (body, &shapeDefinition, &polygon) |> ignore
-
-    let private addCapsule body width height =
-        let mutable shapeDefinition = B2Types.b2DefaultShapeDef ()
-        shapeDefinition.density <- 1f
-        let radius = height / (2f * Meter)
-        let halfSegment = (width - height) / (2f * Meter)
-        let mutable capsule =
-            B2Capsule (B2Vec2 (-halfSegment, 0f), B2Vec2 (halfSegment, 0f), radius)
-        B2Shapes.b2CreateCapsuleShape (body, &shapeDefinition, &capsule) |> ignore
-
-    let private addPolygon1 body =
-        let points =
-            Sandbox2dGeometry.CarContour
-            |> Array.map (fun point ->
-                (point - Sandbox2dGeometry.CarContourBounds.Center) *
-                Sandbox2dGeometry.RaceCourseScale /
-                Meter)
-            |> Array.map (fun point -> B2Vec2 (point.X, point.Y))
-        let mutable hull = B2Hulls.b2ComputeHull (points.AsSpan (), points.Length)
-        let mutable polygon = B2Geometries.b2MakePolygon (&hull, 0f)
-        let mutable definition = B2Types.b2DefaultShapeDef ()
-        definition.density <- Sandbox2dGeometry.CarChassisDensity
-        definition.material.friction <- Sandbox2dGeometry.CarChassisFriction
-        B2Shapes.b2CreatePolygonShape (body, &definition, &polygon) |> ignore
-
-    let private speed body =
-        let mutable velocity = B2Bodies.b2Body_GetLinearVelocity body
-        sqrt (B2MathFunction.b2Dot (&velocity, &velocity))
-
-    let private kineticEnergy body =
-        let mutable velocity = B2Bodies.b2Body_GetLinearVelocity body
-        let angularVelocity = B2Bodies.b2Body_GetAngularVelocity body
-        let mass = B2Bodies.b2Body_GetMass body
-        let inertia = B2Bodies.b2Body_GetRotationalInertia body
-        0.5f * mass * B2MathFunction.b2Dot (&velocity, &velocity) +
-        0.5f * inertia * angularVelocity * angularVelocity
-
-    let private jointError bodyA bodyB (localA : B2Vec2) (localB : B2Vec2) =
-        let mutable transformA =
-            B2Transform (B2Bodies.b2Body_GetPosition bodyA, B2Bodies.b2Body_GetRotation bodyA)
-        let mutable transformB =
-            B2Transform (B2Bodies.b2Body_GetPosition bodyB, B2Bodies.b2Body_GetRotation bodyB)
-        let mutable localA = localA
-        let mutable localB = localB
-        let mutable pointA = B2MathFunction.b2TransformPoint (&transformA, &localA)
-        let mutable pointB = B2MathFunction.b2TransformPoint (&transformB, &localB)
-        B2MathFunction.b2Distance (&pointA, &pointB)
-
-    let private simulateBridge collideConnected =
-        let world = createWorld1 (B2Vec2 (0f, -9.80665f))
-        try
-            let start = 80f
-            let pitch = Sandbox2dGeometry.BridgeLinkPitch / Constants.Engine.Meter2d
-            let finish = start + single Sandbox2dGeometry.BridgeLinkCount * pitch
-            let leftAnchor = createBody4 world B2BodyType.b2_staticBody start 0f
-            let rightAnchor = createBody4 world B2BodyType.b2_staticBody finish 0f
-            let links =
-                [|for index in 0 .. Sandbox2dGeometry.BridgeLinkCount - 1 do
-                   let link =
-                       createBody4 world B2BodyType.b2_dynamicBody (start + (single index + 0.5f) * pitch) 0f
-                   addBox4 link (pitch / 2f)
-                       (Sandbox2dGeometry.BridgeLinkThickness / Constants.Engine.Meter2d / 2f) 1f
-                   B2Bodies.b2Body_SetAngularVelocity (link, if index % 2 = 0 then 1.5f else -1.5f)
-                   link |]
-            let joints = ResizeArray<_> ()
-
-            let createRevoluteJoint bodyA bodyB anchorX =
-                let mutable definition = B2Joints.b2DefaultRevoluteJointDef ()
-                let anchor = B2Vec2 (anchorX, 0f)
-                definition.``base``.bodyIdA <- bodyA
-                definition.``base``.bodyIdB <- bodyB
-                let localA = B2Bodies.b2Body_GetLocalPoint (bodyA, anchor)
-                let localB = B2Bodies.b2Body_GetLocalPoint (bodyB, anchor)
-                definition.``base``.localFrameA.p <- localA
-                definition.``base``.localFrameB.p <- localB
-                definition.``base``.collideConnected <- collideConnected
-                joints.Add (bodyA, bodyB, localA, localB)
-                B2Joints.b2CreateRevoluteJoint (world, &definition) |> ignore
-
-            createRevoluteJoint leftAnchor links[0] start
-            for index in 1 .. links.Length - 1 do
-                createRevoluteJoint links[index - 1] links[index] (start + single index * pitch)
-            createRevoluteJoint links[links.Length - 1] rightAnchor finish
-
-            let mutable transientSpeed = 0f
-            for _ in 1 .. 600 do
-                step 1 world
-                transientSpeed <- max transientSpeed (links |> Array.map speed |> Array.max)
-            let maximumSpeed = links |> Array.map speed |> Array.max
-            let maximumError =
-                joints
-                |> Seq.map (fun (bodyA, bodyB, localA, localB) -> jointError bodyA bodyB localA localB)
-                |> Seq.max
-            (maximumSpeed, maximumError, transientSpeed)
-        finally
-            B2Worlds.b2DestroyWorld world
-
     [<Test>]
-    let ``Production bridge chain settles with collision disabled`` () =
-        let (speed, error, transient) = simulateBridge Sandbox2dGeometry.BridgeCollideConnected
-        let (controlSpeed, controlError, controlTransient) = simulateBridge true
-        let message =
-            $"bridge production speed={speed} error={error} transient={transient}; " +
-            $"control speed={controlSpeed} error={controlError} transient={controlTransient}"
-        Console.WriteLine message
-        Assert.That (speed, Is.LessThan 3f)
-        Assert.That (error, Is.LessThan 0.03f)
-
-    [<Test>]
-    let ``Bridge endpoints are separated by the requested minimum span`` () =
-        let (first, last) = Sandbox2dGeometry.bridgeEndpoints Vector3.Zero Vector2.Zero
-        let distance = (first - last).Magnitude
-        Assert.That (distance, Is.GreaterThanOrEqualTo Sandbox2dGeometry.MinimumBridgeSpan)
-
-        let (first, last) =
-            Sandbox2dGeometry.bridgeEndpoints (Vector3 (10f, 20f, 0f)) (Vector2 (96f, 32f))
-        Assert.That (first.X, Is.EqualTo 106f)
-        Assert.That (last.Y, Is.EqualTo -12f)
-        Assert.That ((first + last) * 0.5f, Is.EqualTo (Vector3 (10f, 20f, 0f)))
-
-    [<Test>]
-    let ``Bridge links are centered between endpoints with the expected pitch`` () =
-        let (centers, pitch) =
-            Sandbox2dGeometry.bridgeLinkCenters
-                (Vector3 (-320f, 0f, 0f))
-                (Vector3 (320f, 0f, 0f))
-                Sandbox2dGeometry.BridgeLinkCount
-        Assert.That (centers.Length, Is.EqualTo Sandbox2dGeometry.BridgeLinkCount)
-        Assert.That (centers.[0].X, Is.EqualTo -304f)
-        Assert.That (centers[centers.Length - 1].X, Is.EqualTo 304f)
-        Assert.That (pitch, Is.EqualTo Sandbox2dGeometry.BridgeLinkPitch)
+    let ``Car source contract preserves contour origin and wheel tuning`` () =
+        Assert.That (Sandbox2dGeometry.CarContour.Length, Is.EqualTo 8)
+        Assert.That (Sandbox2dGeometry.CarContourBounds.Center, Is.EqualTo (v2 0f 0.285f))
+        Assert.That (Sandbox2dGeometry.CarContour[0], Is.EqualTo (v2 -2.5f -0.08f))
+        Assert.That (Sandbox2dGeometry.CarContour[7], Is.EqualTo (v2 -2.25f -0.35f))
+        Assert.That (Sandbox2dGeometry.CarRearWheelModelOffset, Is.EqualTo (v2 -1.709f 0.78f))
+        Assert.That (Sandbox2dGeometry.CarWheelDampingRatio, Is.EqualTo 0.7f)
+        Assert.That (Sandbox2dGeometry.CarChassisDensity, Is.EqualTo 2f)
+        let back, front = Sandbox2dGeometry.CarWheelSpecs[0], Sandbox2dGeometry.CarWheelSpecs[1]
+        Assert.That (back, Is.EqualTo ("Back", v2 -1.709f 0.78f, 0.8f, 4f, 0.9f, 20f, true))
+        Assert.That (front, Is.EqualTo ("Front", v2 1.54f 0.8f, 1f, 4f, 0.2f, 10f, false))
 
     [<Test>]
     let ``Ragdoll arm center leaves torso clearance`` () =
-        let torsoWidth = 30f
-        let armLength = 24f
-        let centerX = Sandbox2dGeometry.ragdollArmCenterX torsoWidth armLength 1f
-        let edgeToEdgeClearance = centerX - armLength / 2f - torsoWidth / 2f
-        Assert.That (edgeToEdgeClearance, Is.EqualTo Sandbox2dGeometry.RagdollArmClearance)
+        let centerX = Sandbox2dGeometry.ragdollArmCenterX 30f 24f 1f
+        Assert.That (centerX - 12f - 15f, Is.EqualTo Sandbox2dGeometry.RagdollArmClearance)
 
     [<Test>]
-    let ``Car spawn height leaves wheel clearance above track`` () =
-        let height = Sandbox2dGeometry.carSpawnHeight 100f 12f Sandbox2dGeometry.CarWheelRadius
-        Assert.That (
-            height + 12f - Sandbox2dGeometry.CarWheelRadius,
-            Is.EqualTo (100f + Sandbox2dGeometry.CarTrackClearance))
-
-    [<Test>]
-    let ``Bubble visual size doubles a nonnegative radius`` () =
-        let radius = 12f
-        Assert.That (Sandbox2dGeometry.bubbleDiameter radius, Is.EqualTo (radius * 2f))
+    let ``Ragdoll torso joints use exact shared anchors`` () =
+        let spacing = Sandbox2dGeometry.RagdollLimbSpacing
+        let upper = Sandbox2dGeometry.ragdollTorsoJointLocalOffset spacing false
+        let lower = Sandbox2dGeometry.ragdollTorsoJointLocalOffset spacing true
+        Assert.That (upper + lower, Is.EqualTo 0f)
+        Assert.That (abs upper, Is.EqualTo (spacing / 2f))
 
     [<Test>]
     let ``Right upper arm anchor preserves authored increment`` () =
-        let anchor =
-            Sandbox2dGeometry.limbJointAnchor
-                (v3 120f 80f 0f)
-                (v3 37f 40f 0f)
-                (v3 30f 0f 0f)
+        let anchor = Sandbox2dGeometry.limbJointAnchor (v3 120f 80f 0f) (v3 37f 40f 0f) (v3 30f 0f 0f)
         Assert.That (anchor, Is.EqualTo (v3 142f 120f 0f))
 
-    let private runFixture useProductionJoint =
-        let mutable worldDefinition = B2Types.b2DefaultWorldDef ()
-        worldDefinition.gravity <- B2Vec2 (0f, 0f)
-        let world = B2Worlds.b2CreateWorld &worldDefinition
-        try
-            let spawnCenter = v3Zero
-            let torsoCenter = v3 0f 40f 0f
-            let armCenter = v3 (if useProductionJoint then 37f else 33f) 40f 0f
-            let armIncrement = v3 30f 0f 0f
-            let torso = createBody2 world (toPhysics (spawnCenter + torsoCenter))
-            let arm = createBody2 world (toPhysics (spawnCenter + armCenter))
-            addCapsule torso 40f 20f
-            addCapsule arm 30f 15f
-            let anchor =
-                Sandbox2dGeometry.limbJointAnchor spawnCenter armCenter armIncrement
-                |> toPhysics
-            let mutable localA = B2Bodies.b2Body_GetLocalPoint (torso, anchor)
-            let mutable localB = B2Bodies.b2Body_GetLocalPoint (arm, anchor)
-            if useProductionJoint then
-                let mutable jointDefinition = B2Joints.b2DefaultRevoluteJointDef ()
-                jointDefinition.``base``.bodyIdA <- torso
-                jointDefinition.``base``.bodyIdB <- arm
-                jointDefinition.``base``.localFrameA.p <- localA
-                jointDefinition.``base``.localFrameB.p <- localB
-                jointDefinition.``base``.collideConnected <- false
-                B2Joints.b2CreateRevoluteJoint (world, &jointDefinition) |> ignore
-            else
-                let mutable jointDefinition = B2Joints.b2DefaultDistanceJointDef ()
-                jointDefinition.``base``.bodyIdA <- torso
-                jointDefinition.``base``.bodyIdB <- arm
-                jointDefinition.``base``.localFrameA.p <- localA
-                jointDefinition.``base``.localFrameB.p <- localB
-                jointDefinition.``base``.collideConnected <- true
-                jointDefinition.length <- 4f / Meter
-                jointDefinition.enableSpring <- true
-                jointDefinition.hertz <- 25f
-                jointDefinition.dampingRatio <- 1f
-                B2Joints.b2CreateDistanceJoint (world, &jointDefinition) |> ignore
-            B2Bodies.b2Body_SetAngularVelocity (arm, 2f)
-            let initialEnergy = kineticEnergy torso + kineticEnergy arm
-            let mutable peakEnergy = initialEnergy
-            let mutable peakAnchorError = 0f
-            for _ in 1 .. 30 do
-                step 1 world
-                peakEnergy <- max peakEnergy (kineticEnergy torso + kineticEnergy arm)
-                let mutable torsoTransform =
-                    B2Transform (B2Bodies.b2Body_GetPosition torso, B2Bodies.b2Body_GetRotation torso)
-                let mutable armTransform =
-                    B2Transform (B2Bodies.b2Body_GetPosition arm, B2Bodies.b2Body_GetRotation arm)
-                let mutable torsoAnchor =
-                    B2MathFunction.b2TransformPoint (&torsoTransform, &localA)
-                let mutable armAnchor =
-                    B2MathFunction.b2TransformPoint (&armTransform, &localB)
-                peakAnchorError <- max peakAnchorError (B2MathFunction.b2Distance (&torsoAnchor, &armAnchor))
-            let mutable torsoTransform =
-                B2Transform (B2Bodies.b2Body_GetPosition torso, B2Bodies.b2Body_GetRotation torso)
-            let mutable armTransform =
-                B2Transform (B2Bodies.b2Body_GetPosition arm, B2Bodies.b2Body_GetRotation arm)
-            let mutable torsoAnchor =
-                B2MathFunction.b2TransformPoint (&torsoTransform, &localA)
-            let mutable armAnchor =
-                B2MathFunction.b2TransformPoint (&armTransform, &localB)
-            let finalAnchorError = B2MathFunction.b2Distance (&torsoAnchor, &armAnchor)
-            Console.WriteLine
-                ($"ragdoll fixture production={useProductionJoint} initialEnergy={initialEnergy} " +
-                 $"peakEnergy={peakEnergy} peakAnchorError={peakAnchorError} " +
-                 $"finalAnchorError={finalAnchorError}")
-            { InitialEnergy = initialEnergy
-              PeakEnergy = peakEnergy
-              FinalAnchorError = finalAnchorError
-              PeakAnchorError = peakAnchorError }
-        finally
-            B2Worlds.b2DestroyWorld world
+    [<Test>]
+    let ``Bridge links share authored endpoints at arbitrary angle`` () =
+        let first, last = v3 10f 20f 0f, v3 106f 52f 0f
+        let endpoints = Sandbox2dGeometry.bridgeLinkEndpoints first last 6
+        Assert.That (endpoints.Length, Is.EqualTo 6)
+        for i in 1 .. endpoints.Length - 1 do Assert.That (snd endpoints[i - 1], Is.EqualTo (fst endpoints[i]))
+        let point ((first : Vector3), (last : Vector3)) positive =
+            let halfLength = (last - first).Magnitude / 2f
+            (first + last) / 2f + ((Sandbox2dGeometry.bridgeJointLocalEndpoint halfLength positive).Transform (Sandbox2dGeometry.bridgeRotation first last)).V3
+        for endpointPair in endpoints do
+            Assert.That ((point endpointPair true - snd endpointPair).Magnitude, Is.LessThan 0.001f)
+            Assert.That ((point endpointPair false - fst endpointPair).Magnitude, Is.LessThan 0.001f)
 
     [<Test>]
-    let ``Right upper arm revolute joint remains stable after perturbation`` () =
-        let production = runFixture true
-        let oldControl = runFixture false
-        Console.WriteLine
-            ($"ragdoll production peak energy={production.PeakEnergy}; " +
-             $"old control peak energy={oldControl.PeakEnergy}")
-        Assert.That (production.PeakEnergy, Is.LessThanOrEqualTo (production.InitialEnergy * 1.001f))
-        Assert.That (production.PeakAnchorError, Is.LessThanOrEqualTo Constants.Physics.Collision2dLinearSlop)
-        Assert.That (oldControl.PeakEnergy, Is.GreaterThan (oldControl.InitialEnergy * 10f))
-        Assert.That (production.PeakEnergy, Is.LessThan (oldControl.PeakEnergy * 0.1f))
-
-    let private runCar motorSpeed =
-        let world = createWorld ()
-        try
-            let track = createBody3 world B2BodyType.b2_staticBody (B2Vec2 (0f, -0.05f))
-            addBox5 track 100f 0.05f 0f Constants.Physics.FrictionDefault
-
-            let rearOffsetY =
-                Sandbox2dGeometry.carWheelOffset Sandbox2dGeometry.CarRearWheelModelOffset 0f
-                |> fun offset -> offset.Y
-            let spawnHeight =
-                Sandbox2dGeometry.carSpawnHeight 0f rearOffsetY Sandbox2dGeometry.CarWheelRadius
-                / Meter
-            let chassis = createBody3 world B2BodyType.b2_dynamicBody (B2Vec2 (0f, spawnHeight))
-            addPolygon1 chassis
-
-            let wheelPairs =
-                Sandbox2dGeometry.CarWheelSpecs
-                |> Array.map (fun (_name, position, density, frequency, friction, maxTorque, isMotor) ->
-                    createWheel world chassis (B2Vec2 (0f, spawnHeight))
-                        (position, density, frequency, friction, maxTorque, isMotor))
-            let wheels = wheelPairs |> Array.map fst
-            let rearMotorJoint = wheelPairs[0] |> snd
-            B2WheelJoints.b2WheelJoint_SetMotorSpeed (rearMotorJoint, motorSpeed)
-            B2WheelJoints.b2WheelJoint_EnableMotor (rearMotorJoint, true)
-            step 600 world
-
-            let chassisVelocity = B2Bodies.b2Body_GetLinearVelocity chassis
-            let rearWheelBottom =
-                B2Bodies.b2Body_GetPosition wheels[0]
-                |> fun position -> position.Y - Sandbox2dGeometry.CarWheelRadius / Meter
-            let rotation = B2Bodies.b2Body_GetRotation chassis
-            (abs (MathF.Atan2 (rotation.s, rotation.c)), rearWheelBottom, abs chassisVelocity.X)
-        finally
-            B2Worlds.b2DestroyWorld world
+    let ``Bridge endpoints are separated by the requested minimum span`` () =
+        let first, last = Sandbox2dGeometry.bridgeEndpoints v3Zero v2Zero
+        Assert.That ((first - last).Magnitude, Is.GreaterThanOrEqualTo Sandbox2dGeometry.MinimumBridgeSpan)
 
     [<Test>]
-    let ``Production car motor avoids high speed instability`` () =
-        let (pitch, rearClearance, velocity) = runCar Sandbox2dGeometry.CarMotorSpeedMax
-        let (oldPitch, oldRearClearance, oldVelocity) = runCar 50f
-        Console.WriteLine (
-            $"car production pitch={pitch} rear clearance={rearClearance} velocity={velocity}; "
-            + $"old pitch={oldPitch} rear clearance={oldRearClearance} velocity={oldVelocity}")
-        Assert.That (pitch, Is.LessThan 0.1f)
-        Assert.That (rearClearance, Is.GreaterThan (-0.02f))
-        Assert.That (rearClearance, Is.GreaterThan (oldRearClearance + 0.01f))
-        Assert.That (velocity, Is.LessThan (oldVelocity * 0.5f))
+    let ``Race track contour preserves Nu ghost endpoints and authored order`` () =
+        let contour = Sandbox2dGeometry.RaceTrackContour
+        Assert.That (contour.Length, Is.EqualTo 36)
+        Assert.That (contour[0], Is.EqualTo (v2 310f 5f))
+        Assert.That (contour[0], Is.EqualTo contour[1])
+        Assert.That (contour[34], Is.EqualTo contour[35])
+        Assert.That (contour[35], Is.EqualTo (v2 -20f 5f))
+
+    [<Test>]
+    let ``Teeter source contract preserves start pose and limits`` () =
+        Assert.That (Sandbox2dGeometry.TeeterInitialAngle, Is.EqualTo 0f)
+        Assert.That (Sandbox2dGeometry.TeeterCenterY, Is.EqualTo 1f)
+        Assert.That (Sandbox2dGeometry.TeeterBoardHalfLength, Is.EqualTo 10f)
+        Assert.That (Sandbox2dGeometry.TeeterBoardHalfThickness, Is.EqualTo 0.25f)
+        Assert.That (Sandbox2dGeometry.TeeterAngleLimit, Is.EqualTo (8f * MathF.PI / 180f))
+
+    let private makeIntegrationWorldWithPhysics () =
+        let plugin = SandBox2dPlugin ()
+        let windowSize = Constants.Render.DisplayVirtualResolution
+        let windowViewport = Viewport.makeWindow1 windowSize
+        let geometryViewport = Viewport.makeGeometry windowViewport.Bounds.Size
+        let renderer = StubRendererProcess () :> RendererProcess
+        let dependencies =
+            { SdlDepsOpt = None
+              ImGui = ImGui (true, windowViewport.Bounds.Size)
+              PhysicsEngine2d = plugin.MakePhysicsEngine2d ()
+              PhysicsEngine3d = StubPhysicsEngine.make ()
+              RendererPhysics3dOpt = None
+              RendererProcess = renderer
+              AudioPlayer = StubAudioPlayer.make ()
+              CursorClient = StubCursorClient.make () }
+        let world = World.make (constant None) (SuppliedDependencies dependencies) { WorldConfig.defaultConfig with Accompanied = true } windowSize geometryViewport windowViewport plugin
+        world, dependencies.PhysicsEngine2d
+
+    let private makeIntegrationWorld () = makeIntegrationWorldWithPhysics () |> fst
+
+    [<Test; Category "Integration">]
+    let ``FluidSim real bubble visual and physics sizes agree`` () =
+        Nu.init ()
+        let world, physicsEngine2d = makeIntegrationWorldWithPhysics ()
+        let mutable overlayObserved = false
+        let mutable bubbleObserved = false
+        let mutable mousePressed = false
+        let mutable overlayInset : Box2 option = None
+        let mutable bubbleInset : Box2 option = None
+        let mutable bubbleSize = v3Zero
+        let mutable bubbleScale = v3Zero
+        let mutable bubbleRadius = 0f
+        let mutable bodyShapeRadius = 0f
+        let mutable bubbleResizeFrames = 0
+        let mutable previousBubbleSize = v3Zero
+        let mutable colliderAligned = false
+        let mutable overlapReady = false
+        let mutable staleEventCycleCompleted = false
+        let mutable firstIntegrationContact = false
+        let mutable bubbleBodyExistedBeforePropagation = false
+        let mutable bubbleBodyExistedAfterPropagation = false
+        let runWhile (world : World) = world.UpdateTime < 120L
+        let preProcess (world : World) =
+            World.setFramePacing false world
+            Game.SetGameState FluidSim world
+            let overlay : Entity = Simulants.FluidSimScene / "Tool Panel" / "Bubble Overlay"
+            if overlay.GetExists world then
+                overlayObserved <- true
+                overlayInset <- overlay.GetInsetOpt world
+                let screen = Simulants.FluidSim
+                screen.SetSelectedTool Bubble world
+                let feeler : Entity = Simulants.FluidSimScene / "Feeler"
+                if feeler.GetExists world && not mousePressed then
+                    World.publishPlus
+                        { Position = World.getMousePosition world
+                          Button = MouseLeft
+                          Down = true }
+                        Nu.Game.Handle.MouseLeftDownEvent
+                        EventTrace.empty
+                        feeler
+                        false
+                        false
+                        world
+                    mousePressed <- true
+                let bubble : Entity = Simulants.FluidSimScene / "Bubble"
+                if bubble.GetExists world then
+                    bubbleObserved <- true
+                    bubbleInset <- bubble.GetInsetOpt world
+                    bubbleSize <- bubble.GetSize world
+                    if bubbleSize <> previousBubbleSize then
+                        bubbleResizeFrames <- inc bubbleResizeFrames
+                        previousBubbleSize <- bubbleSize
+                    bubbleRadius <- screen.GetMouseBubbleSize world
+                    bubbleScale <- bubble.GetScale world
+                    let circle : Entity = Simulants.FluidSimScene / "Circle"
+                    if circle.GetExists world then
+                        circle.SetBodyType Dynamic world
+                        circle.SetSensor true world
+                        circle.SetPosition (bubble.GetPosition world) world
+                        circle.SetLinearVelocity v3Zero world
+                        colliderAligned <- true
+                        if not staleEventCycleCompleted && overlapReady then
+                            let bubbleBodyId = bubble.GetBodyId world
+                            let circleBodyId = circle.GetBodyId world
+                            circle.PropagatePhysics world
+                            bubble.PropagatePhysics world
+                            bubbleBodyExistedBeforePropagation <- physicsEngine2d.GetBodyExists bubbleBodyId
+                            firstIntegrationContact <-
+                                match physicsEngine2d.TryIntegrate (GameTime.ofUpdates 1L) with
+                                | Some messages ->
+                                    let mutable found = false
+                                    for message in messages do
+                                        match message with
+                                        | BodyPenetrationMessage penetration ->
+                                            found <- found ||
+                                                ((penetration.BodyShapeSource.BodyId = bubbleBodyId && penetration.BodyShapeTarget.BodyId = circleBodyId) ||
+                                                 (penetration.BodyShapeSource.BodyId = circleBodyId && penetration.BodyShapeTarget.BodyId = bubbleBodyId))
+                                        | _ -> ()
+                                    found
+                                | None -> false
+                            bubble.SetSize (bubble.GetSize world + v3 1f 1f 0f) world
+                            bubble.PropagatePhysics world
+                            bubbleBodyExistedAfterPropagation <- physicsEngine2d.GetBodyExists bubbleBodyId
+                            physicsEngine2d.TryIntegrate (GameTime.ofUpdates 1L) |> ignore
+                            staleEventCycleCompleted <- true
+                        overlapReady <- true
+                    match bubble.GetBodyShape world with
+                    | SphereShape sphere -> bodyShapeRadius <- sphere.Radius
+                    | _ -> ()
+        let collision2dFrameCompensation = Constants.Physics.Collision2dFrameCompensation
+        Constants.Physics.Collision2dFrameCompensation <- false
+        let result =
+            try World.runWithCleanUp runWhile preProcess ignore ignore ignore ignore (Some ignore) world
+            finally Constants.Physics.Collision2dFrameCompensation <- collision2dFrameCompensation
+        Assert.That (result, Is.EqualTo Constants.Engine.ExitCodeSuccess)
+        Assert.That (overlayObserved, Is.True)
+        Assert.That (bubbleObserved, Is.True)
+        Assert.That (colliderAligned, Is.True)
+        Assert.That (staleEventCycleCompleted, Is.True)
+        Assert.That (bubbleBodyExistedBeforePropagation, Is.True)
+        Assert.That (bubbleBodyExistedAfterPropagation, Is.True)
+        Assert.That (firstIntegrationContact, Is.True, "first integration did not report Bubble/Circle penetration")
+        Assert.That (bubbleResizeFrames, Is.GreaterThan 10,
+            $"bubble was resized for only {bubbleResizeFrames} frames")
+        Assert.That (overlayInset, Is.EqualTo (Some Sandbox2dGeometry.BubbleImageInset))
+        Assert.That (bubbleInset, Is.EqualTo (Some Sandbox2dGeometry.BubbleImageInset))
+        Assert.That (bubbleInset.Value.Min, Is.EqualTo (v2 133f 129f))
+        Assert.That (bubbleInset.Value.Size, Is.EqualTo (v2 748f 810f))
+        Assert.That (bubbleSize.X, Is.EqualTo (Sandbox2dGeometry.bubbleDiameter bubbleRadius))
+        Assert.That (bubbleSize.Y, Is.EqualTo bubbleSize.X)
+        Assert.That (bubbleScale, Is.EqualTo v3One)
+        Assert.That (bodyShapeRadius, Is.EqualTo 0.5f)
+
+    [<Test; Category "Integration">]
+    let ``RaceCourse real car reaches final wall`` () =
+        Nu.init ()
+        let world = makeIntegrationWorld ()
+        let car : Entity = Simulants.RaceCourseScene / "Car"
+        let boxes : Entity array = [| for i in 0 .. 2 -> Simulants.RaceCourseScene / $"Box {i}" |]
+        let mutable maximumFront = Single.NegativeInfinity
+        let mutable latestFront = Single.NegativeInfinity
+        let maximumBoxFronts = Array.create boxes.Length Single.NegativeInfinity
+        let latestBoxFronts = Array.create boxes.Length Single.NegativeInfinity
+        let latestBoxWidths = Array.create boxes.Length 0f
+        let latestBoxPositions = Array.create boxes.Length v3Zero
+        let mutable observed = false
+        let mutable maximumTime = 0L
+        let mutable maximumPosition = v3Zero
+        let mutable maximumVelocity = v3Zero
+        let mutable maximumAngularVelocity = v3Zero
+        let mutable maximumAngle = 0f
+        let mutable latestTime = 0L
+        let mutable latestPosition = v3Zero
+        let mutable latestVelocity = v3Zero
+        let mutable latestAngularVelocity = v3Zero
+        let mutable latestAngle = 0f
+        let mutable commandedAcceleration = 0f
+        let accelerationStep =
+            match Constants.GameTime.DesiredFrameRate with
+            | StaticFrameRate rate
+            | DynamicFrameRate rate -> 2f / single rate
+        let runWhile (world : World) = world.UpdateTime < 3600L && maximumFront < 310f * Sandbox2dGeometry.RaceCourseScale
+        let preProcess (world : World) =
+            World.setFramePacing false world
+            Game.SetGameState RaceCourse world
+            if Simulants.RaceCourse.GetExists world then
+                commandedAcceleration <- max (commandedAcceleration - accelerationStep) -1f
+                Simulants.RaceCourse.SetCarAcceleration commandedAcceleration world
+            if car.GetExists world then
+                observed <- true
+                let position = car.GetPosition world
+                let velocity = car.GetLinearVelocity world
+                let angularVelocity = car.GetAngularVelocity world
+                let angle = car.GetRotation world |> _.Angle2d
+                let front = (car.GetPerimeterMax world).X
+                latestFront <- front
+                latestTime <- world.UpdateTime
+                latestPosition <- position
+                latestVelocity <- velocity
+                latestAngularVelocity <- angularVelocity
+                latestAngle <- angle
+                if front > maximumFront then
+                    maximumFront <- front
+                    maximumTime <- world.UpdateTime
+                    maximumPosition <- position
+                    maximumVelocity <- velocity
+                    maximumAngularVelocity <- angularVelocity
+                    maximumAngle <- angle
+            for i, box in Array.indexed boxes do
+                if box.GetExists world then
+                    let perimeterMax = box.GetPerimeterMax world
+                    let perimeterMin = box.GetPerimeterMin world
+                    let front = perimeterMax.X
+                    maximumBoxFronts[i] <- max maximumBoxFronts[i] front
+                    latestBoxFronts[i] <- front
+                    latestBoxWidths[i] <- perimeterMax.X - perimeterMin.X
+                    latestBoxPositions[i] <- box.GetPosition world
+        let result = World.runWithCleanUp runWhile preProcess ignore ignore ignore ignore (Some ignore) world
+        Assert.That (result, Is.EqualTo Constants.Engine.ExitCodeSuccess)
+        Assert.That (observed, Is.True)
+        let boxFronts = maximumBoxFronts |> Array.map (fun x -> x / Sandbox2dGeometry.RaceCourseScale) |> Array.map string |> (fun values -> String.Join (",", values))
+        let boxPositions = latestBoxPositions |> Array.map string |> (fun values -> String.Join (",", values))
+        let latestBoxIndex = latestBoxFronts |> Array.mapi (fun i front -> i, front) |> Array.maxBy snd |> fst
+        let latestBoxFront = latestBoxFronts[latestBoxIndex]
+        let latestBoxWidth = latestBoxWidths[latestBoxIndex]
+        let endpointTolerance = 2f * Constants.Physics.Collision2dLinearSlop * Constants.Engine.Meter2d
+        Assert.That (latestBoxFront, Is.InRange (310f * Sandbox2dGeometry.RaceCourseScale - endpointTolerance, 310f * Sandbox2dGeometry.RaceCourseScale + endpointTolerance),
+            $"latest box index={latestBoxIndex} front authored={latestBoxFront / Sandbox2dGeometry.RaceCourseScale}; width={latestBoxWidth / Sandbox2dGeometry.RaceCourseScale}; boxes max fronts authored={boxFronts}; latest positions={boxPositions}")
+        Assert.That (latestFront, Is.GreaterThanOrEqualTo (310f * Sandbox2dGeometry.RaceCourseScale - latestBoxWidth - endpointTolerance),
+            $"maximum front authored={maximumFront / Sandbox2dGeometry.RaceCourseScale}; max t={maximumTime} pos={maximumPosition} vel={maximumVelocity} angular={maximumAngularVelocity} angle={maximumAngle}; latest t={latestTime} pos={latestPosition} vel={latestVelocity} angular={latestAngularVelocity} angle={latestAngle}; boxes max fronts authored={boxFronts} latest positions={boxPositions}")
+        Assert.That (maximumFront, Is.LessThanOrEqualTo (310f * Sandbox2dGeometry.RaceCourseScale + Constants.Physics.Collision2dLinearSlop * Constants.Engine.Meter2d))
+
+    [<Test; Category "Integration">]
+    let ``ToyBox real bridge links settle`` () =
+        Nu.init ()
+        let world = makeIntegrationWorld ()
+        let toyBox = Simulants.ToyBox
+        let avatar : Entity = Simulants.ToyBoxScene / "Avatar"
+        let endpoints : Entity array = [| Simulants.ToyBoxScene / "Bridge"; Simulants.ToyBoxScene / "Bridge Opposite End" |]
+        let links : Entity array = [| for i in 0 .. 5 -> Simulants.ToyBoxScene / $"Bridge Paddle {i}" |]
+        let mutable observed = false
+        let mutable latestEndpointPositions = Array.zeroCreate<Vector3> endpoints.Length
+        let mutable latestEndpointSizes = Array.zeroCreate<Vector3> endpoints.Length
+        let mutable endpointBodyTypes = Array.create endpoints.Length Dynamic
+        let mutable endpointSensors = Array.create endpoints.Length false
+        let mutable maximumLinear = 0f
+        let mutable maximumAngular = 0f
+        let mutable latestLinear = 0f
+        let mutable latestAngular = 0f
+        let mutable consecutiveSettled = 0
+        let mutable dragFrame = 0
+        let mutable dragStep = v3Zero
+        let mutable resizedObserved = false
+        let mutable dragCompleted = false
+        let mutable initialLinkSizes = Array.zeroCreate<Vector3> links.Length
+        let runWhile (world : World) = world.UpdateTime < 1800L && consecutiveSettled < 60
+        let preProcess (world : World) =
+            World.setFramePacing false world
+            Game.SetGameState ToyBox world
+            if toyBox.GetExists world then toyBox.SetToys (FMap.empty |> FMap.add "Bridge" Bridge) world
+            // Disable the avatar because it spawns inside the chain; this isolates bridge self-stability from that unrelated contact.
+            if avatar.GetExists world then avatar.SetBodyEnabled false world
+            if endpoints |> Array.forall (fun endpoint -> endpoint.GetExists world) && links |> Array.forall (fun link -> link.GetExists world) then
+                observed <- true
+                if dragFrame = 0 then
+                    for i in 0 .. links.Length - 1 do initialLinkSizes[i] <- links[i].GetSize world
+                    dragStep <- (endpoints[1].GetPosition world - endpoints[0].GetPosition world) / 16f
+                    endpoints[0].SetBodyType Dynamic world
+                    dragFrame <- 1
+                elif dragFrame <= 4 then
+                    endpoints[0].SetPosition (endpoints[0].GetPosition world + dragStep) world
+                    endpoints[0].SetLinearVelocity v3Zero world
+                    dragFrame <- inc dragFrame
+                elif not dragCompleted then
+                    endpoints[0].SetBodyType Static world
+                    dragCompleted <- true
+                for i in 0 .. endpoints.Length - 1 do
+                    latestEndpointPositions[i] <- endpoints[i].GetPosition world
+                    latestEndpointSizes[i] <- endpoints[i].GetSize world
+                    endpointBodyTypes[i] <- endpoints[i].GetBodyType world
+                    endpointSensors[i] <- endpoints[i].GetSensor world
+                let mutable currentLinear = 0f
+                let mutable currentAngular = 0f
+                for link in links do
+                    currentLinear <- max currentLinear (link.GetLinearVelocity world).Magnitude
+                    currentAngular <- max currentAngular (link.GetAngularVelocity world).Magnitude
+                latestLinear <- currentLinear
+                latestAngular <- currentAngular
+                maximumLinear <- max maximumLinear currentLinear
+                maximumAngular <- max maximumAngular currentAngular
+                if dragFrame > 0 then
+                    let endpointPairs = Sandbox2dGeometry.bridgeLinkEndpoints (endpoints[0].GetPosition world) (endpoints[1].GetPosition world) links.Length
+                    resizedObserved <-
+                        resizedObserved ||
+                            Array.mapi2 (fun i ((endpoint1, endpoint2) : Vector3 * Vector3) (link : Entity) ->
+                                let expectedLength = (endpoint2 - endpoint1).Magnitude
+                                abs ((link.GetSize world).Y - expectedLength) < 0.01f && abs ((link.GetSize world).Y - initialLinkSizes[i].Y) > 0.01f) endpointPairs links
+                            |> Array.forall id
+                if dragCompleted && resizedObserved && currentLinear < 0.1f && currentAngular < 0.1f then consecutiveSettled <- consecutiveSettled + 1
+                else consecutiveSettled <- 0
+        let result = World.runWithCleanUp runWhile preProcess ignore ignore ignore ignore (Some ignore) world
+        Assert.That (result, Is.EqualTo Constants.Engine.ExitCodeSuccess)
+        Assert.That (observed, Is.True)
+        Assert.That (dragCompleted, Is.True)
+        Assert.That (resizedObserved, Is.True, "bridge paddle sizes did not follow the dragged endpoint")
+        for i in 0 .. endpoints.Length - 1 do
+            Assert.That (endpointBodyTypes[i], Is.EqualTo Static,
+                $"endpoint={endpoints[i].Name}; position={latestEndpointPositions[i]}; size={latestEndpointSizes[i]}; body type={endpointBodyTypes[i]}; sensor={endpointSensors[i]}")
+            Assert.That (endpointSensors[i], Is.True,
+                $"endpoint={endpoints[i].Name}; position={latestEndpointPositions[i]}; size={latestEndpointSizes[i]}; body type={endpointBodyTypes[i]}; sensor={endpointSensors[i]}")
+        let finalEndpointPairs = Sandbox2dGeometry.bridgeLinkEndpoints latestEndpointPositions[0] latestEndpointPositions[1] links.Length
+        let endpointTolerance = 4f * Constants.Physics.Collision2dLinearSlop * Constants.Engine.Meter2d
+        let worldEndpoint (link : Entity) positive =
+            let halfLength = link.GetSize world |> fun size -> size.Y / 2f
+            let local = Sandbox2dGeometry.bridgeJointLocalEndpoint halfLength positive
+            link.GetPosition world + (local.Transform (link.GetRotation world)).V3
+        for i in 0 .. links.Length - 1 do
+            let _, expectedLast = finalEndpointPairs[i]
+            let expectedLength = (expectedLast - fst finalEndpointPairs[i]).Magnitude
+            Assert.That ((links[i].GetSize world).Y, Is.InRange (expectedLength - endpointTolerance, expectedLength + endpointTolerance),
+                $"paddle={links[i].Name}; expected span={(expectedLast - fst finalEndpointPairs[i]).Magnitude}; actual size={(links[i].GetSize world).Y}")
+        let anchorStart = latestEndpointPositions[0]
+        let anchorEnd = latestEndpointPositions[1]
+        Assert.That ((worldEndpoint links[0] false - anchorStart).Magnitude, Is.LessThanOrEqualTo endpointTolerance)
+        for i in 1 .. links.Length - 1 do
+            Assert.That ((worldEndpoint links[i - 1] true - worldEndpoint links[i] false).Magnitude, Is.LessThanOrEqualTo endpointTolerance,
+                $"joint={i}; separation={(worldEndpoint links[i - 1] true - worldEndpoint links[i] false).Magnitude}; tolerance={endpointTolerance}")
+        Assert.That ((worldEndpoint (Array.last links) true - anchorEnd).Magnitude, Is.LessThanOrEqualTo endpointTolerance)
+        let endpointSpan = (latestEndpointPositions[0] - latestEndpointPositions[1]).Magnitude
+        Assert.That (consecutiveSettled, Is.GreaterThanOrEqualTo 60,
+            $"settled frames={consecutiveSettled}; latest linear={latestLinear}; latest angular={latestAngular}; maximum linear={maximumLinear}; maximum angular={maximumAngular}; endpoint 1 position={latestEndpointPositions[0]}; size={latestEndpointSizes[0]}; body type={endpointBodyTypes[0]}; sensor={endpointSensors[0]}; endpoint 2 position={latestEndpointPositions[1]}; size={latestEndpointSizes[1]}; body type={endpointBodyTypes[1]}; sensor={endpointSensors[1]}; span={endpointSpan}")
+
+    [<Test; Category "Integration">]
+    let ``ToyBox real ragdoll head stays clear of torso`` () =
+        Nu.init ()
+        let world = makeIntegrationWorld ()
+        let toyBox = Simulants.ToyBox
+        let ragdollName = "Ragdoll"
+        let head : Entity = Simulants.ToyBoxScene / ragdollName
+        let torso : Entity = head / $"{ragdollName} Torso Upper"
+        let mutable minimumClearance = Single.PositiveInfinity
+        let mutable observed = false
+        let mutable perturbed = false
+        let runWhile (world : World) = world.UpdateTime < 240L
+        let preProcess (world : World) =
+            World.setFramePacing false world
+            Game.SetGameState ToyBox world
+            if toyBox.GetExists world then toyBox.SetToys (FMap.empty |> FMap.add ragdollName Ragdoll) world
+            if head.GetExists world && torso.GetExists world then
+                observed <- true
+                if not perturbed then head.SetAngularVelocity (v3 0f 0f 8f) world; perturbed <- true
+                let local = (head.GetPosition world - torso.GetPosition world).Transform (torso.GetRotation world).Inverted
+                let halfSegment = (torso.GetSize world).X / 2f - (torso.GetSize world).Y / 2f
+                let closestX = max (-halfSegment) (min halfSegment local.X)
+                let distance = sqrt ((local.X - closestX) ** 2f + local.Y ** 2f)
+                minimumClearance <- min minimumClearance (distance - ((head.GetSize world).X + (torso.GetSize world).Y) / 2f)
+        let result = World.runWithCleanUp runWhile preProcess ignore ignore ignore ignore (Some ignore) world
+        Assert.That (result, Is.EqualTo Constants.Engine.ExitCodeSuccess)
+        Assert.That (observed, Is.True)
+        Assert.That (minimumClearance, Is.GreaterThanOrEqualTo (-2f * Constants.Physics.Collision2dLinearSlop * Constants.Engine.Meter2d))

--- a/Projects/Sand Box 2d/Sandbox2dGeometry.fs
+++ b/Projects/Sand Box 2d/Sandbox2dGeometry.fs
@@ -94,7 +94,9 @@ module Sandbox2dGeometry =
         [| ("Back", CarRearWheelModelOffset, 0.8f, 4f, 0.9f, 20f, true)
            ("Front", v2 1.54f 0.8f, 1f, 4f, 0.2f, 10f, false) |]
 
-    /// The authored open contour used by the race-course ground.
+    // Open contours reserve their first and last points as ghost vertices for seamless joins.
+    // This standalone course duplicates its second and second-to-last points, then reverses the array
+    // because ContourShape collides on each link's right-hand side.
     let RaceTrackContour =
         [|v2 -20f 5f; v2 -20f 5f; v2 -20f 0f; v2 20f 0f; v2 25f 0.25f; v2 30f 1f; v2 35f 4f; v2 40f 0f; v2 45f 0f;
           v2 50f -1f; v2 55f -2f; v2 60f -2f; v2 65f -1.25f; v2 70f 0f; v2 75f 0.3f; v2 80f 1.5f; v2 85f 3.5f;

--- a/Projects/Sand Box 2d/Sandbox2dGeometry.fs
+++ b/Projects/Sand Box 2d/Sandbox2dGeometry.fs
@@ -16,14 +16,26 @@ module Sandbox2dGeometry =
     [<Literal>]
     let RaceCourseScale = 16f
 
+    /// Conversion from authored source units to Nu physics meters.
+    let SourceToPhysicsScale = RaceCourseScale / Constants.Engine.Meter2d
+
+    /// Source-authored dynamic density scales with the inverse square of the authored-to-physics length conversion.
+    let SourceMassScale = 1f / (SourceToPhysicsScale * SourceToPhysicsScale)
+
+    /// Source-authored torque and angular impulse scale with the square of the authored-to-physics length conversion.
+    let SourceTorqueScale = SourceToPhysicsScale * SourceToPhysicsScale
+
+    /// Aether's source gravity (-10 source units/s^2), expressed in Nu pixel units.
+    let SourceGravity = -10f * RaceCourseScale
+
     [<Literal>]
-    let CarMotorSpeedMax = 8f
+    let CarMotorSpeedMax = 50f
 
     [<Literal>]
     let BridgeLinkCount = 20
 
     [<Literal>]
-    let BridgeLinkPitch = 32f
+    let BridgeSagRatio = 0.025f
 
     [<Literal>]
     let BridgeLinkThickness = 4f
@@ -41,35 +53,55 @@ module Sandbox2dGeometry =
     let RagdollLimbSpacing = 20f
 
     [<Literal>]
-    let CarTrackClearance = 8f
+    let TeeterBoardHalfLength = 10f
+
+    [<Literal>]
+    let TeeterBoardHalfThickness = 0.25f
+
+    let TeeterAngleLimit = 8f * MathF.PI / 180f
+    let TeeterInitialAngle = 0f
+    let TeeterCenterY = 1f
+
+    let TeeterAngularImpulse = 100f * SourceTorqueScale
+
+    [<Literal>]
+    let RagdollTorsoJointHalfSpacing = 0.5f
 
     [<Literal>]
     let BridgeCollideConnected = false
 
+    [<Literal>]
+    let BridgeLinearDamping = 1f
+
+    [<Literal>]
+    let BridgeAngularDamping = 1f
+
     let CarContour =
-        [|v2 -2.5f 0.92f; v2 -2.375f 1.46f; v2 -0.58f 1.92f; v2 0.46f 1.92f
-          v2 2.5f 1.17f; v2 2.5f 0.795f; v2 2.3f 0.67f; v2 -2.25f 0.65f|]
+        [|v2 -2.5f -0.08f; v2 -2.375f 0.46f; v2 -0.58f 0.92f; v2 0.46f 0.92f
+          v2 2.5f 0.17f; v2 2.5f -0.205f; v2 2.3f -0.33f; v2 -2.25f -0.35f|]
 
     let CarContourBounds = Box2.Enclose CarContour
 
     let CarRearWheelModelOffset = v2 -1.709f 0.78f
 
-    let CarChassisDensity = 4f
+    let CarChassisDensity = 2f
 
     let CarChassisFriction = 0.2f
 
-    let CarWheelDampingRatio = 0.85f
+    let CarWheelDampingRatio = 0.7f
 
     let CarWheelSpecs : (string * Vector2 * single * single * single * single * bool) array =
-        [| ("Back", CarRearWheelModelOffset, 0.8f, 5f, 0.9f, 20f, true)
-           ("Front", v2 1.54f 0.8f, 1f, 8.5f, 0.2f, 10f, false) |]
+        [| ("Back", CarRearWheelModelOffset, 0.8f, 4f, 0.9f, 20f, true)
+           ("Front", v2 1.54f 0.8f, 1f, 4f, 0.2f, 10f, false) |]
 
-    let CarWheelRadius = RaceCourseScale / 2f
-
-    let carWheelOffset position rotation =
-        position - CarContourBounds.Center
-        |> fun value -> value.Rotate rotation
-        |> fun value -> value * RaceCourseScale
+    /// The authored open contour used by the race-course ground.
+    let RaceTrackContour =
+        [|v2 -20f 5f; v2 -20f 5f; v2 -20f 0f; v2 20f 0f; v2 25f 0.25f; v2 30f 1f; v2 35f 4f; v2 40f 0f; v2 45f 0f;
+          v2 50f -1f; v2 55f -2f; v2 60f -2f; v2 65f -1.25f; v2 70f 0f; v2 75f 0.3f; v2 80f 1.5f; v2 85f 3.5f;
+          v2 90f 0f; v2 95f -0.5f; v2 100f -1f; v2 105f -2f; v2 110f -2.5f; v2 115f -1.3f; v2 120f 0f; v2 160f 0f;
+          v2 159f -10f; v2 201f -10f; v2 200f 0f; v2 240f 0f; v2 250f 5f; v2 250f -10f; v2 270f -10f; v2 270f 0f;
+          v2 310f 0f; v2 310f 5f; v2 310f 5f|]
+        |> Array.rev
 
     let carSize =
         CarContour
@@ -83,14 +115,35 @@ module Sandbox2dGeometry =
             else v2 (MinimumBridgeSpan / 2f) 0f
         (center + offset.V3, center - offset.V3)
 
-    let bridgeLinkCenters (first : Vector3) (last : Vector3) linkCount =
+    let bridgeLinkEndpoints (first : Vector3) (last : Vector3) linkCount =
         if linkCount <= 0 then invalidArg (nameof linkCount) "Bridge link count must be positive."
         let delta = (last - first) / single linkCount
-        [| for i in 0 .. linkCount - 1 -> first + delta * (single i + 0.5f) |], delta.Magnitude
+        let perpendicular =
+            let value = v3 -(last.Y - first.Y) (last.X - first.X) 0f
+            if value.Y < 0f then value else -value
+        let points =
+            [| for i in 0 .. linkCount ->
+                let t = single i / single linkCount
+                first + delta * single i + perpendicular * (4f * t * (1f - t) * BridgeSagRatio) |]
+        [| for i in 0 .. linkCount - 1 -> points[i], points[i + 1] |]
+
+    let bridgeJointLocalEndpoint halfLength towardPositive =
+        v2 0f (if towardPositive then halfLength else -halfLength)
+
+    /// Rotation used by both bridge renderings and physics.  Links use their
+    /// local Y axis for the span, hence the quarter-turn from the span angle.
+    let bridgeRotation (first : Vector3) (last : Vector3) =
+        Quaternion.CreateFromAngle2d (MathF.Atan2 (last.Y - first.Y, last.X - first.X) - MathF.PI_OVER_2)
+
+    let ragdollTorsoJointLocalOffset torsoHeight towardPositive =
+        torsoHeight * RagdollTorsoJointHalfSpacing * (if towardPositive then 1f else -1f)
 
     let bubbleDiameter radius =
         if radius < 0f then invalidArg (nameof radius) "Bubble radius cannot be negative."
         radius * BubbleDiameterPerRadius
+
+    /// The authored bubble artwork includes transparent padding around its visible pixels.
+    let BubbleImageInset = box2 (v2 133f 129f) (v2 748f 810f)
 
     let ragdollArmCenterX torsoWidth armLength direction =
         direction * (torsoWidth / 2f + armLength / 2f + RagdollArmClearance)
@@ -99,5 +152,6 @@ module Sandbox2dGeometry =
     let limbJointAnchor (spawnCenter : Vector3) (pos : Vector3) (posIncrement : Vector3) =
         spawnCenter + pos - posIncrement / 2f
 
-    let carSpawnHeight trackHeight wheelOffsetY wheelRadius =
-        trackHeight + CarTrackClearance + wheelRadius - wheelOffsetY
+
+    let carMotorSpeed acceleration =
+        single (sign acceleration) * Math.SmoothStep (0f, CarMotorSpeedMax, abs acceleration)

--- a/Projects/Sand Box 2d/ToyBox.fs
+++ b/Projects/Sand Box 2d/ToyBox.fs
@@ -283,51 +283,70 @@ type ToyBoxDispatcher () =
         // declare anchor 1
         let offset = v2 (Gen.randomf1 500f - 250f) (Gen.randomf1 350f - 175f)
         let (anchorPosition1, anchorPosition2) = Sandbox2dGeometry.bridgeEndpoints spawnCenter offset
-        World.doOrbBody2d name [Entity.Position |= anchorPosition1] world |> ignore
+        World.doOrbBody2d name
+            [Entity.Position |= anchorPosition1
+             Entity.BodyType .= Static
+             Entity.Sensor .= true] world |> ignore
         let anchor1 = world.DeclaredEntity
 
         // declare anchor 2
-        World.doOrbBody2d $"{name} Opposite End" [Entity.Position |= anchorPosition2] world |> ignore
+        World.doOrbBody2d $"{name} Opposite End"
+            [Entity.Position |= anchorPosition2
+             Entity.BodyType .= Static
+             Entity.Sensor .= true] world |> ignore
         let anchor2 = world.DeclaredEntity
 
         // adjust position of link relative to each anchor as the anchors are dragged around
-        let direction = anchor2.GetPosition world - anchor1.GetPosition world
-        if direction <> v3Zero then
-            let rotation = Quaternion.CreateLookAt2d (v2 -direction.Y direction.X)
-            anchor1.SetRotation rotation world
-            anchor2.SetRotation rotation world
-
+        let currentAnchorPosition1 = anchor1.GetPosition world
+        let currentAnchorPosition2 = anchor2.GetPosition world
         // declare bridge links
         let names = Array.init 6 (sprintf "%s Paddle %d" name)
-        let linkCenters, boxHeight =
-            Sandbox2dGeometry.bridgeLinkCenters anchorPosition1 anchorPosition2 names.Length
+        let endpointPairs = Sandbox2dGeometry.bridgeLinkEndpoints currentAnchorPosition1 currentAnchorPosition2 names.Length
+        let desiredSizes = endpointPairs |> Array.map (fun (endpoint1, endpoint2) -> v3 Sandbox2dGeometry.BridgeLinkThickness (endpoint2 - endpoint1).Magnitude 0f)
+        let bridgeResized =
+            names
+            |> Array.mapi (fun i linkName ->
+                let link = world.ContextGroup / linkName
+                link.GetExists world && link.GetSize world <> desiredSizes[i])
+            |> Array.exists id
         for i in 0 .. Array.length names - 1 do
+            let endpoint1, endpoint2 = endpointPairs[i]
             World.doBoxBody2d names[i]
-                [Entity.Position |= linkCenters[i]
-                 Entity.Rotation |= Quaternion.CreateLookAt2d (v2 -direction.Y direction.X)
-                 Entity.Size @= v3 4f boxHeight 0f
+                [Entity.Position |= (endpoint1 + endpoint2) / 2f
+                 Entity.Rotation |= Sandbox2dGeometry.bridgeRotation endpoint1 endpoint2
+                 Entity.Size @= desiredSizes[i]
+                 Entity.LinearDamping .= Sandbox2dGeometry.BridgeLinearDamping
+                 Entity.AngularDamping .= Sandbox2dGeometry.BridgeAngularDamping
                  Entity.StaticImage .= Assets.Default.Paddle
                  // paddles are thin, so use continuous collision detection to prevent tunnelling at high velocities
                  Entity.CollisionDetection .= Continuous] world |> ignore
 
         // declare revolute joints to link the bridge links together and to the anchors
-        for (n1, n2) in Array.pairwise [|anchor1.Name; yield! names; anchor2.Name|] do
+        for jointIndex in 0 .. names.Length do
+            let n1, n2 = (Array.pairwise [|anchor1.Name; yield! names; anchor2.Name|]).[jointIndex]
+            let bodyJoint = Box2dNetBodyJoint { CreateBodyJoint = fun toPhysics _ a b world ->
+                // a revolute joint is like a hinge or pin where two bodies rotate about a common point.
+                let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
+                jointDef.``base``.bodyIdA <- a
+                jointDef.``base``.bodyIdB <- b
+                jointDef.``base``.localFrameA.p <-
+                    if jointIndex = 0 then B2MathFunction.b2Vec2_zero
+                    else
+                        let p1, p2 = endpointPairs[jointIndex - 1]
+                        Sandbox2dGeometry.bridgeJointLocalEndpoint (toPhysics ((p2 - p1).Magnitude / 2f)) true |> fun p -> B2Vec2 (p.X, p.Y)
+                jointDef.``base``.localFrameB.p <-
+                    if jointIndex = names.Length then B2MathFunction.b2Vec2_zero
+                    else
+                        let p1, p2 = endpointPairs[jointIndex]
+                        Sandbox2dGeometry.bridgeJointLocalEndpoint (toPhysics ((p2 - p1).Magnitude / 2f)) false |> fun p -> B2Vec2 (p.X, p.Y)
+                B2Joints.b2CreateRevoluteJoint (world, &jointDef) }
+            let bodyJointProperty = if bridgeResized then Entity.BodyJoint @= bodyJoint else Entity.BodyJoint |= bodyJoint
             World.doBodyJoint2d $"{n2} Link"
                 [Entity.BodyJointTarget .= Address.makeFromString $"^/{n1}"
                  Entity.BodyJointTarget2 .= Address.makeFromString $"^/{n2}"
                  // adjacent links already meet at the hinge anchor; collision impulses would fight the constraint.
                  Entity.CollideConnected .= Sandbox2dGeometry.BridgeCollideConnected
-                 Entity.BodyJoint @= Box2dNetBodyJoint { CreateBodyJoint = fun _ _ a b world ->
-                    // a revolute joint is like a hinge or pin, where two bodies rotate about a common point. in this
-                    // case, the bottom center point of body A shares the same position as the top center point of body
-                    // B, where they can rotate freely relative to each other.
-                    let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
-                    jointDef.``base``.bodyIdA <- a
-                    jointDef.``base``.bodyIdB <- b
-                    let anchor = (B2Bodies.b2Body_GetPosition a + B2Bodies.b2Body_GetPosition b) * 0.5f
-                    jointDef.``base``.localFrameA.p <- B2Bodies.b2Body_GetLocalPoint (a, anchor)
-                    jointDef.``base``.localFrameB.p <- B2Bodies.b2Body_GetLocalPoint (b, anchor)
-                    B2Joints.b2CreateRevoluteJoint (world, &jointDef) }] world |> ignore
+                 bodyJointProperty] world |> ignore
 
     static let declareFan name spawnCenter (toyBox : Screen) world =
 
@@ -461,19 +480,24 @@ type ToyBoxDispatcher () =
                     let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
                     jointDef.``base``.bodyIdA <- a
                     jointDef.``base``.bodyIdB <- b
-                    jointDef.``base``.localFrameA.p <- new _ (0f, -0.55f * toPhysics torsoHeight)
-                    jointDef.``base``.localFrameB.p <- new _ (0f, 0.55f * toPhysics torsoHeight)
+                    jointDef.``base``.localFrameA.p <- new _ (0f, Sandbox2dGeometry.ragdollTorsoJointLocalOffset (toPhysics torsoHeight) false)
+                    jointDef.``base``.localFrameB.p <- new _ (0f, Sandbox2dGeometry.ragdollTorsoJointLocalOffset (toPhysics torsoHeight) true)
                     jointDef.enableLimit <- true // angle limits are allowed for revolute joints
                     jointDef.lowerAngle <- -revoluteAngle
                     jointDef.upperAngle <- revoluteAngle
                     B2Joints.b2CreateRevoluteJoint (world, &jointDef)
                 | _ ->
-                    let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
+                    let mutable jointDef = B2Joints.b2DefaultDistanceJointDef ()
                     jointDef.``base``.bodyIdA <- a
                     jointDef.``base``.bodyIdB <- b
                     jointDef.``base``.localFrameA.p <- new _ (0f, -0.5f * toPhysics torsoHeight)
                     jointDef.``base``.localFrameB.p <- new _ (0f, 0.5f * toPhysics torsoHeight)
-                    B2Joints.b2CreateRevoluteJoint (world, &jointDef) }
+                    jointDef.length <- toPhysics 1f
+                    jointDef.enableSpring <- true
+                    jointDef.hertz <- 25f
+                    jointDef.dampingRatio <- 1f
+                    jointDef.``base``.collideConnected <- true
+                    B2Joints.b2CreateDistanceJoint (world, &jointDef) }
             World.doBodyJoint2d $"{name} {connectsTo}<->{componentName}"
                 [Entity.BodyJoint |= twoBodyJoint
                  Entity.BodyJointTarget .=
@@ -481,7 +505,7 @@ type ToyBoxDispatcher () =
                     then Address.makeFromString $"^/^/{name}" // special case for head as parent
                     else Address.makeFromString $"^/{name} {connectsTo}"
                  Entity.BodyJointTarget2 .= Address.makeFromString $"^/{name} {componentName}"
-                 Entity.CollideConnected .= false
+                 Entity.CollideConnected .= (connectsTo = "Head")
                  Entity.MountOpt .= None] world |> ignore
 
         // declare arms and legs

--- a/Projects/Sand Box 2d/ToyBox.fs
+++ b/Projects/Sand Box 2d/ToyBox.fs
@@ -285,14 +285,12 @@ type ToyBoxDispatcher () =
         let (anchorPosition1, anchorPosition2) = Sandbox2dGeometry.bridgeEndpoints spawnCenter offset
         World.doOrbBody2d name
             [Entity.Position |= anchorPosition1
-             Entity.BodyType .= Static
              Entity.Sensor .= true] world |> ignore
         let anchor1 = world.DeclaredEntity
 
         // declare anchor 2
         World.doOrbBody2d $"{name} Opposite End"
             [Entity.Position |= anchorPosition2
-             Entity.BodyType .= Static
              Entity.Sensor .= true] world |> ignore
         let anchor2 = world.DeclaredEntity
 
@@ -329,6 +327,8 @@ type ToyBoxDispatcher () =
                 let mutable jointDef = B2Joints.b2DefaultRevoluteJointDef ()
                 jointDef.``base``.bodyIdA <- a
                 jointDef.``base``.bodyIdB <- b
+                // Links span local Y, with each joint connecting A's positive endpoint to B's negative endpoint.
+                // Anchor endpoints use the body centers.
                 jointDef.``base``.localFrameA.p <-
                     if jointIndex = 0 then B2MathFunction.b2Vec2_zero
                     else


### PR DESCRIPTION
## Summary

- restore the Sand Box 2d racecourse car, teeter, bridge, and ragdoll behavior with source-scaled physics values
- resize ToyBox bridge paddles and joints from their dragged endpoints, and crop FluidSim bubble artwork to its physical bounds
- support explicitly supplied World dependencies and a lifecycle-safe stub renderer so integration tests use real Nu entities
- skip stale Box2D contact and sensor events after their shapes or bodies have been destroyed
- resolve the bundled macOS Vulkan loader for SDL from the managed output directory while retaining loader-based MoltenVK and KosmicKrisp selection

## Validation

- Sand Box 2d focused FluidSim test: 10/10 repeated passes
- Sand Box 2d full suite: 12/12 passed
- Nu.Tests project build: passed with 0 errors
- Nu.Tests selected engine/world coverage: 9/11 passed; the two SDL-window tests stop at `SDL_Init` with `No available video device` on this automation host, before window creation or Vulkan loading
- the output-local `libvulkan.1.dylib` exports `vkGetInstanceProcAddr`; targeted `vulkaninfo` runs through that loader discovered both the MoltenVK and KosmicKrisp ICDs
- `git diff --check` passed; modified F# and project files have no ending newline